### PR TITLE
Option to start at login

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const {
 	isAppVisible,
 	isTrayEnabled,
 	store,
+	startAtLogin,
 } = require("./store");
 const { fileExists, injectCSS } = require("./plugins/utils");
 const { isTesting } = require("./utils/testing");
@@ -169,6 +170,11 @@ app.on("ready", () => {
 	setApplicationMenu();
 	mainWindow = createMainWindow();
 	setUpTray(app, mainWindow);
+
+	// Autostart at login
+	app.setLoginItemSettings({
+		openAtLogin: startAtLogin(),
+	});
 
 	if (!is.dev() && autoUpdate()) {
 		autoUpdater.checkForUpdatesAndNotify();

--- a/menu.js
+++ b/menu.js
@@ -1,4 +1,5 @@
 const { app, Menu } = require("electron");
+const is = require("electron-is");
 
 const { getAllPlugins } = require("./plugins/utils");
 const {
@@ -9,6 +10,7 @@ const {
 	isAppVisible,
 	isTrayEnabled,
 	setOptions,
+	startAtLogin,
 } = require("./store");
 
 const mainMenuTemplate = [
@@ -40,6 +42,20 @@ const mainMenuTemplate = [
 					setOptions({ autoUpdates: item.checked });
 				},
 			},
+			...(is.windows() || is.macOS()
+				? // Only works on Win/Mac
+				  // https://www.electronjs.org/docs/api/app#appsetloginitemsettingssettings-macos-windows
+				  [
+						{
+							label: "Start at login",
+							type: "checkbox",
+							checked: startAtLogin(),
+							click: (item) => {
+								setOptions({ startAtLogin: item.checked });
+							},
+						},
+				  ]
+				: []),
 			{
 				label: "Tray",
 				submenu: [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "youtube-music",
 	"productName": "YouTube Music",
-	"version": "1.3.3",
+	"version": "1.4.0",
 	"description": "YouTube Music Desktop App - including custom plugins",
 	"license": "MIT",
 	"repository": "th-ch/youtube-music",

--- a/store/index.js
+++ b/store/index.js
@@ -5,16 +5,17 @@ const store = new Store({
 	defaults: {
 		"window-size": {
 			width: 1100,
-			height: 550
+			height: 550,
 		},
 		url: "https://music.youtube.com",
 		plugins: ["navigation", "shortcuts", "adblocker"],
 		options: {
 			tray: false,
 			appVisible: true,
-			autoUpdates: true
-		}
-	}
+			autoUpdates: true,
+			startAtLogin: false,
+		},
+	},
 });
 
 module.exports = {
@@ -29,5 +30,6 @@ module.exports = {
 		store.set("options", { ...store.get("options"), ...options }),
 	isTrayEnabled: () => store.get("options.tray"),
 	isAppVisible: () => store.get("options.appVisible"),
-	autoUpdate: () => store.get("options.autoUpdates")
+	autoUpdate: () => store.get("options.autoUpdates"),
+	startAtLogin: () => store.get("options.startAtLogin"),
 };


### PR DESCRIPTION
This PR addresses https://github.com/th-ch/youtube-music/issues/18#issuecomment-650788822 by adding an option to start the application at login (using [login item settings from electron](https://www.electronjs.org/docs/api/app#appsetloginitemsettingssettings-macos-windows), only available for Win/Mac). 