### PR TITLE
Bump to node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: "10"
+node_js: "12"
 env:
   - ELECTRON_CACHE=$HOME/.cache/electron ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ init:
 
 install:
   # Install node
-  - ps: Install-Product node 10 x64
+  - ps: Install-Product node 12 x64
   # Install dependencies
   - yarn --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"release:win": "yarn run clean && electron-builder --win -p always"
 	},
 	"engines": {
+		"node": ">=12.16.1",
 		"npm": "Please use yarn and not npm"
 	},
 	"dependencies": {


### PR DESCRIPTION
This PR bumps node from 10 to 12 following https://github.com/th-ch/youtube-music/commit/e197087a5027af1ca71ecde7bbdf6351137555b9 which adds a downloader plugin, relying on ffmpeg-wasm which requires node >= 12.