### PR TITLE
add Download Folder Chooser

### DIFF
--- a/plugins/downloader/menu.js
+++ b/plugins/downloader/menu.js
@@ -9,6 +9,8 @@ const ytpl = require("ytpl");
 const { sendError } = require("./back");
 const { defaultMenuDownloadLabel, getFolder } = require("./utils");
 
+const { setOptions } = require('../../config/plugins')
+const { dialog } = require('electron');
 let downloadLabel = defaultMenuDownloadLabel;
 
 module.exports = (win, options, refreshMenu) => [
@@ -59,5 +61,18 @@ module.exports = (win, options, refreshMenu) => [
 				);
 			});
 		},
+	},
+	{
+		label: 'Choose download folder:',
+		click: () => {
+			let result = dialog.showOpenDialogSync({ 
+				properties: ['openDirectory', 'createDirectory'],
+				defaultPath: Array.isArray(options.downloadFolder) ? options.downloadFolder[0] : undefined,
+			})
+			if(result) {
+				options.downloadFolder = result
+				setOptions("downloader", options)
+			} //else = user pressed cancel
+		}
 	},
 ];

--- a/plugins/downloader/menu.js
+++ b/plugins/downloader/menu.js
@@ -67,11 +67,11 @@ module.exports = (win, options, refreshMenu) => [
 		click: () => {
 			let result = dialog.showOpenDialogSync({ 
 				properties: ['openDirectory', 'createDirectory'],
-				defaultPath: Array.isArray(options.downloadFolder) ? options.downloadFolder[0] : undefined,
+				defaultPath: getFolder(options.downloadFolder),
 			})
 			if(result) {
-				options.downloadFolder = result
-				setOptions("downloader", options)
+				options.downloadFolder = result[0];
+				setOptions("downloader", options);
 			} //else = user pressed cancel
 		}
 	},


### PR DESCRIPTION
### Works flawlessly **but** : 


* As of now downloadsFolder() from[ `download-folder`](https://www.npmjs.com/package/downloads-folder) throws an error and I don't think its from my side (tried alot of things, and all the other modules work)

EDIT: One day later. it suddenly works now, apparently was an error on their end
<details>
  <summary><b>Error Code for downloadsFolder()</b></summary><p>

    Error:
    Error: Module did not self-register: '\\?\c:\youtube-music\node_modules\registry-js\build\Release\registry.node'.
    at process.func [as dlopen] (electron/js2c/asar_bundle.js:5:1812)
    at Object.Module._extensions..node (internal/modules/cjs/loader.js:1203:18)
    at Object.func [as .node] (electron/js2c/asar_bundle.js:5:1812)
    at Module.load (internal/modules/cjs/loader.js:992:32)
    at Module._load (internal/modules/cjs/loader.js:885:14)
    at Function.f._load (electron/js2c/asar_bundle.js:5:12738)
    at Module.require (internal/modules/cjs/loader.js:1032:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.<anonymous> (c:\Users\Araxeus\git\youtube-music\node_modules\registry-js\dist\lib\registry.js:5:7)
    at Module._compile (internal/modules/cjs/loader.js:1152:30)
</p>
</details>