### PR TITLE
Refresh menu on plugin enable/disable (show/hide submenu)

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -7,7 +7,7 @@ const is = require("electron-is");
 const { getAllPlugins } = require("./plugins/utils");
 const config = require("./config");
 
-const pluginEnabledMenu = (win, plugin, label = "") => ({
+const pluginEnabledMenu = (win, plugin, label = "", hasSubmenu=false) => ({
 	label: label || plugin,
 	type: "checkbox",
 	checked: config.plugins.isEnabled(plugin),
@@ -17,7 +17,9 @@ const pluginEnabledMenu = (win, plugin, label = "") => ({
 		} else {
 			config.plugins.disable(plugin);
 		}
-		this.setApplicationMenu(win);
+		if(hasSubmenu) {
+			this.setApplicationMenu(win);
+		}
 	},
 });
 
@@ -28,16 +30,15 @@ const mainMenuTemplate = (win) => [
 			...getAllPlugins().map((plugin) => {
 				const pluginPath = path.join(__dirname, "plugins", plugin, "menu.js");
 
-				if (!config.plugins.isEnabled(plugin)) {
-					return pluginEnabledMenu(win, plugin);
-				}
-
 				if (existsSync(pluginPath)) {
+					if (!config.plugins.isEnabled(plugin)) {
+						return pluginEnabledMenu(win, plugin, "", true);
+					}
 					const getPluginMenu = require(pluginPath);
 					return {
 						label: plugin,
 						submenu: [
-							pluginEnabledMenu(win, plugin, "Enabled"),
+							pluginEnabledMenu(win, plugin, "Enabled", true),
 							...getPluginMenu(win, config.plugins.getOptions(plugin), () =>
 								module.exports.setApplicationMenu(win)
 							),

--- a/menu.js
+++ b/menu.js
@@ -7,7 +7,7 @@ const is = require("electron-is");
 const { getAllPlugins } = require("./plugins/utils");
 const config = require("./config");
 
-const pluginEnabledMenu = (plugin, label = "") => ({
+const pluginEnabledMenu = (win, plugin, label = "") => ({
 	label: label || plugin,
 	type: "checkbox",
 	checked: config.plugins.isEnabled(plugin),
@@ -17,6 +17,7 @@ const pluginEnabledMenu = (plugin, label = "") => ({
 		} else {
 			config.plugins.disable(plugin);
 		}
+		this.setApplicationMenu(win);
 	},
 });
 
@@ -28,7 +29,7 @@ const mainMenuTemplate = (win) => [
 				const pluginPath = path.join(__dirname, "plugins", plugin, "menu.js");
 
 				if (!config.plugins.isEnabled(plugin)) {
-					return pluginEnabledMenu(plugin);
+					return pluginEnabledMenu(win, plugin);
 				}
 
 				if (existsSync(pluginPath)) {
@@ -36,7 +37,7 @@ const mainMenuTemplate = (win) => [
 					return {
 						label: plugin,
 						submenu: [
-							pluginEnabledMenu(plugin, "Enabled"),
+							pluginEnabledMenu(win, plugin, "Enabled"),
 							...getPluginMenu(win, config.plugins.getOptions(plugin), () =>
 								module.exports.setApplicationMenu(win)
 							),
@@ -44,7 +45,7 @@ const mainMenuTemplate = (win) => [
 					};
 				}
 
-				return pluginEnabledMenu(plugin);
+				return pluginEnabledMenu(win, plugin);
 			}),
 			{ type: "separator" },
 			{

--- a/plugins/styled-bars/back.js
+++ b/plugins/styled-bars/back.js
@@ -22,7 +22,6 @@ let win;
 let done = false;
 
 module.exports = winImport => {	
-	//override menu template for custom menu
 	win = winImport;
 	// css for custom scrollbar + disable drag area(was causing bugs)
 	injectCSS(win.webContents, path.join(__dirname, 'style.css'));

--- a/plugins/styled-bars/back.js
+++ b/plugins/styled-bars/back.js
@@ -3,9 +3,9 @@ const { Menu } = require('electron');
 const path = require('path');
 const electronLocalshortcut = require("electron-localshortcut");
 const config = require('../../config');
-var { mainMenuTemplate } = require("../../menu");
+const { setApplicationMenu } = require("../../menu");
 
-//override Menu.buildFromTemplate to also fix menu
+//override Menu.buildFromTemplate, making it also fix the template
 const originBuildMenu = Menu.buildFromTemplate;
 //this function natively gets called on all submenu so no more reason to use recursion
 Menu.buildFromTemplate = function (template) {
@@ -21,7 +21,7 @@ let win;
 //check that menu doesn't get created twice
 let done = false;
 
-module.exports = winImport => {	
+module.exports = winImport => {
 	win = winImport;
 	// css for custom scrollbar + disable drag area(was causing bugs)
 	injectCSS(win.webContents, path.join(__dirname, 'style.css'));
@@ -31,9 +31,9 @@ module.exports = winImport => {
 			return
 		}
 		done = true;
-		let template = mainMenuTemplate(win);
-		let menu = Menu.buildFromTemplate(template);
-		Menu.setApplicationMenu(menu);
+
+		//refresh menu to fix it
+		setApplicationMenu(win);
 		
 		//register keyboard shortcut && hide menu if hideMenu is enabled
 		if (config.get('options.hideMenu')) {
@@ -53,18 +53,17 @@ function switchMenuVisibility() {
 
 //go over each item in menu
 function fixMenu(template) {
-	for (let index in template) {
-		let item = template[index];
+	for (let item of template) {
 		//change onClick of checkbox+radio if not fixed
 		if ((item.type === 'checkbox' || item.type === 'radio') && !item.fixed) {
-			item.fixed = true;
 			let ogOnclick = item.click;
 			item.click = (itemClicked) => {
 				ogOnclick(itemClicked);
 				checkCheckbox(itemClicked);
 			};
+			item.fixed = true;
 		}
-		//customize roles
+		//customize roles (will be deleted soon)
 		else if (item.role != null) {
 			fixRoles(item)
 		}


### PR DESCRIPTION
This allow users to change plugin state + its options, without having to restart the application just to see the options submenu

https://github.com/th-ch/youtube-music/pull/217/commits/adc0d145c320e745f7dc05baf59085741318fae3 fix styled-bars (old name) original function to support all menu changes in the application (not disregarding the new PR, just keeping compatibility with current main branch)

https://github.com/th-ch/youtube-music/pull/217/commits/02d45bed7489dd497d80aa6aad29b1422b2b1b9d  - refresh only if plugin has a menu.js (avoid needless menu refresh)