### PR TITLE
remove 'shortcuts' from default plugins

### DIFF
--- a/config/defaults.js
+++ b/config/defaults.js
@@ -21,21 +21,22 @@ const defaultConfig = {
 		navigation: {
 			enabled: true,
 		},
-		shortcuts: {
-			enabled: true,
-		},
 		adblocker: {
 			enabled: true,
 			cache: true,
 			additionalBlockLists: [], // Additional list of filters, e.g "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters.txt"
 		},
 		// Disabled plugins
+		shortcuts: {
+			enabled: false,
+		},
 		downloader: {
 			enabled: false,
 			ffmpegArgs: [], // e.g. ["-b:a", "192k"] for an audio bitrate of 192kb/s
 			downloadFolder: undefined, // Custom download folder (absolute path)
 		},
 		discord: {
+			enabled: false,
 			activityTimoutEnabled: true, // if enabled, the discord rich presence gets cleared when music paused after the time specified below
 			activityTimoutTime: 10 * 60 * 1000 // 10 minutes
 		},


### PR DESCRIPTION
Resolve #204 , Resolve #50 
shortcuts plugin currently blocks more features than it adds, so it probably shouldn't be enabled by default
* `shortcuts` block native MediaSession OS integration
* The media keys [buttons] controls works natively - without the plugin