### PR TITLE
Allows downloading songs that aren't currently playing

### DIFF
--- a/plugins/downloader/front.js
+++ b/plugins/downloader/front.js
@@ -31,11 +31,16 @@ const reinit = () => {
 	}
 };
 
+const baseUrl = "https://music.youtube.com";
 // TODO: re-enable once contextIsolation is set to true
 // contextBridge.exposeInMainWorld("downloader", {
 // 	download: () => {
 global.download = () => {
-	const videoUrl = global.songInfo.url || window.location.href;
+	let videoUrl = getSongMenu()
+		.querySelector("ytmusic-menu-navigation-item-renderer")
+		.querySelector("#navigation-endpoint")
+		.getAttribute("href");
+	videoUrl = !videoUrl ? (global.songInfo.url || window.location.href) : (baseUrl + videoUrl);
 
 	downloadVideoToMP3(
 		videoUrl,


### PR DESCRIPTION
Fix #210 , Fix #219

This makes it so `Downloader` plugin use the URL of the song that the menu was opened from
(More accurately, it will use the URL of the radio mix for the song, taken from the same menu)

Also Fix #84 - plugin will no longer randomly download a playlist when trying to download a single song from the menu

This is also fully compatible with playlist downloading - effectively allowing users to download 'anything' without having to play it