### PR TITLE
Updated download plugin icon color to match other icons

### DIFF
--- a/plugins/downloader/templates/download.html
+++ b/plugins/downloader/templates/download.html
@@ -9,9 +9,24 @@
 	<div
 		class="menu-icon yt-icon-container yt-icon ytmusic-toggle-menu-service-item-renderer"
 	>
-		<svg id="SvgjsSvg1001" width="288" height="288" xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svgjs="http://svgjs.com/svgjs"><defs id="SvgjsDefs1002"></defs><g id="SvgjsG1008" transform="matrix(0.9167,0,0,0.9167,11.995200000000011,11.995200000000011)"><svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 512 512" viewBox="0 0 512 512" width="288" height="288"><path d="M382.56,233.376C379.968,227.648,374.272,224,368,224h-64V16c0-8.832-7.168-16-16-16h-64c-8.832,0-16,7.168-16,16v208h-64
-			c-6.272,0-11.968,3.68-14.56,9.376c-2.624,5.728-1.6,12.416,2.528,17.152l112,128c3.04,3.488,7.424,5.472,12.032,5.472
-			c4.608,0,8.992-2.016,12.032-5.472l112-128C384.192,245.824,385.152,239.104,382.56,233.376z" fill="#aaaaaa" class="color000 svgShape"></path><path d="M432,352v96H80v-96H16v128c0,17.696,14.336,32,32,32h416c17.696,0,32-14.304,32-32V352H432z" fill="#aaaaaa" class="color000 svgShape"></path></svg></g></svg>
+		<svg
+			viewBox="0 0 24 24"
+			preserveAspectRatio="xMidYMid meet"
+			focusable="false"
+			class="style-scope yt-icon"
+			style="pointer-events: none; display: block; width: 100%; height: 100%;"
+		>
+			<g class="style-scope yt-icon">
+				<path
+					d="M25.462,19.105v6.848H4.515v-6.848H0.489v8.861c0,1.111,0.9,2.012,2.016,2.012h24.967c1.115,0,2.016-0.9,2.016-2.012v-8.861H25.462z"
+					class="style-scope yt-icon" fill="#aaaaaa"
+				/>
+				<path
+					d="M14.62,18.426l-5.764-6.965c0,0-0.877-0.828,0.074-0.828s3.248,0,3.248,0s0-0.557,0-1.416c0-2.449,0-6.906,0-8.723c0,0-0.129-0.494,0.615-0.494c0.75,0,4.035,0,4.572,0c0.536,0,0.524,0.416,0.524,0.416c0,1.762,0,6.373,0,8.742c0,0.768,0,1.266,0,1.266s1.842,0,2.998,0c1.154,0,0.285,0.867,0.285,0.867s-4.904,6.51-5.588,7.193C15.092,18.979,14.62,18.426,14.62,18.426z"
+					class="style-scope yt-icon" fill="#aaaaaa"
+				/>
+			</g>
+		</svg>
 	</div>
 	<div
 		class="text style-scope ytmusic-toggle-menu-service-item-renderer"

--- a/plugins/downloader/templates/download.html
+++ b/plugins/downloader/templates/download.html
@@ -1,36 +1,36 @@
 <div
-	class="menu-item ytmusic-menu-popup-renderer"
-	role="option"
-	tabindex="-1"
-	aria-disabled="false"
-	aria-selected="false"
-	onclick="download()"
+		class="menu-item ytmusic-menu-popup-renderer"
+		role="option"
+		tabindex="-1"
+		aria-disabled="false"
+		aria-selected="false"
+		onclick="download()"
 >
 	<div
-		class="menu-icon yt-icon-container yt-icon ytmusic-toggle-menu-service-item-renderer"
+			class="menu-icon yt-icon-container yt-icon ytmusic-toggle-menu-service-item-renderer"
 	>
 		<svg
-			viewBox="0 0 24 24"
-			preserveAspectRatio="xMidYMid meet"
-			focusable="false"
-			class="style-scope yt-icon"
-			style="pointer-events: none; display: block; width: 100%; height: 100%;"
+				viewBox="0 0 24 24"
+				preserveAspectRatio="xMidYMid meet"
+				focusable="false"
+				class="style-scope yt-icon"
+				style="pointer-events: none; display: block; width: 100%; height: 100%;"
 		>
 			<g class="style-scope yt-icon">
 				<path
-					d="M25.462,19.105v6.848H4.515v-6.848H0.489v8.861c0,1.111,0.9,2.012,2.016,2.012h24.967c1.115,0,2.016-0.9,2.016-2.012v-8.861H25.462z"
-					class="style-scope yt-icon" fill="#aaaaaa"
+						d="M25.462,19.105v6.848H4.515v-6.848H0.489v8.861c0,1.111,0.9,2.012,2.016,2.012h24.967c1.115,0,2.016-0.9,2.016-2.012v-8.861H25.462z"
+						class="style-scope yt-icon" fill="#aaaaaa"
 				/>
 				<path
-					d="M14.62,18.426l-5.764-6.965c0,0-0.877-0.828,0.074-0.828s3.248,0,3.248,0s0-0.557,0-1.416c0-2.449,0-6.906,0-8.723c0,0-0.129-0.494,0.615-0.494c0.75,0,4.035,0,4.572,0c0.536,0,0.524,0.416,0.524,0.416c0,1.762,0,6.373,0,8.742c0,0.768,0,1.266,0,1.266s1.842,0,2.998,0c1.154,0,0.285,0.867,0.285,0.867s-4.904,6.51-5.588,7.193C15.092,18.979,14.62,18.426,14.62,18.426z"
-					class="style-scope yt-icon" fill="#aaaaaa"
+						d="M14.62,18.426l-5.764-6.965c0,0-0.877-0.828,0.074-0.828s3.248,0,3.248,0s0-0.557,0-1.416c0-2.449,0-6.906,0-8.723c0,0-0.129-0.494,0.615-0.494c0.75,0,4.035,0,4.572,0c0.536,0,0.524,0.416,0.524,0.416c0,1.762,0,6.373,0,8.742c0,0.768,0,1.266,0,1.266s1.842,0,2.998,0c1.154,0,0.285,0.867,0.285,0.867s-4.904,6.51-5.588,7.193C15.092,18.979,14.62,18.426,14.62,18.426z"
+						class="style-scope yt-icon" fill="#aaaaaa"
 				/>
 			</g>
 		</svg>
 	</div>
 	<div
-		class="text style-scope ytmusic-toggle-menu-service-item-renderer"
-		id="ytmcustom-download"
+			class="text style-scope ytmusic-toggle-menu-service-item-renderer"
+			id="ytmcustom-download"
 	>
 		Download
 	</div>

--- a/plugins/downloader/templates/download.html
+++ b/plugins/downloader/templates/download.html
@@ -1,36 +1,36 @@
 <div
-		class="menu-item ytmusic-menu-popup-renderer"
-		role="option"
-		tabindex="-1"
-		aria-disabled="false"
-		aria-selected="false"
-		onclick="download()"
+	class="menu-item ytmusic-menu-popup-renderer"
+	role="option"
+	tabindex="-1"
+	aria-disabled="false"
+	aria-selected="false"
+	onclick="download()"
 >
 	<div
-			class="menu-icon yt-icon-container yt-icon ytmusic-toggle-menu-service-item-renderer"
+		class="menu-icon yt-icon-container yt-icon ytmusic-toggle-menu-service-item-renderer"
 	>
 		<svg
-				viewBox="0 0 24 24"
-				preserveAspectRatio="xMidYMid meet"
-				focusable="false"
-				class="style-scope yt-icon"
-				style="pointer-events: none; display: block; width: 100%; height: 100%;"
+			viewBox="0 0 24 24"
+			preserveAspectRatio="xMidYMid meet"
+			focusable="false"
+			class="style-scope yt-icon"
+			style="pointer-events: none; display: block; width: 100%; height: 100%;"
 		>
 			<g class="style-scope yt-icon">
 				<path
-						d="M25.462,19.105v6.848H4.515v-6.848H0.489v8.861c0,1.111,0.9,2.012,2.016,2.012h24.967c1.115,0,2.016-0.9,2.016-2.012v-8.861H25.462z"
-						class="style-scope yt-icon" fill="#aaaaaa"
+					d="M25.462,19.105v6.848H4.515v-6.848H0.489v8.861c0,1.111,0.9,2.012,2.016,2.012h24.967c1.115,0,2.016-0.9,2.016-2.012v-8.861H25.462z"
+					class="style-scope yt-icon" fill="#aaaaaa"
 				/>
 				<path
-						d="M14.62,18.426l-5.764-6.965c0,0-0.877-0.828,0.074-0.828s3.248,0,3.248,0s0-0.557,0-1.416c0-2.449,0-6.906,0-8.723c0,0-0.129-0.494,0.615-0.494c0.75,0,4.035,0,4.572,0c0.536,0,0.524,0.416,0.524,0.416c0,1.762,0,6.373,0,8.742c0,0.768,0,1.266,0,1.266s1.842,0,2.998,0c1.154,0,0.285,0.867,0.285,0.867s-4.904,6.51-5.588,7.193C15.092,18.979,14.62,18.426,14.62,18.426z"
-						class="style-scope yt-icon" fill="#aaaaaa"
+					d="M14.62,18.426l-5.764-6.965c0,0-0.877-0.828,0.074-0.828s3.248,0,3.248,0s0-0.557,0-1.416c0-2.449,0-6.906,0-8.723c0,0-0.129-0.494,0.615-0.494c0.75,0,4.035,0,4.572,0c0.536,0,0.524,0.416,0.524,0.416c0,1.762,0,6.373,0,8.742c0,0.768,0,1.266,0,1.266s1.842,0,2.998,0c1.154,0,0.285,0.867,0.285,0.867s-4.904,6.51-5.588,7.193C15.092,18.979,14.62,18.426,14.62,18.426z"
+					class="style-scope yt-icon" fill="#aaaaaa"
 				/>
 			</g>
 		</svg>
 	</div>
 	<div
-			class="text style-scope ytmusic-toggle-menu-service-item-renderer"
-			id="ytmcustom-download"
+		class="text style-scope ytmusic-toggle-menu-service-item-renderer"
+		id="ytmcustom-download"
 	>
 		Download
 	</div>

--- a/plugins/downloader/templates/download.html
+++ b/plugins/downloader/templates/download.html
@@ -9,24 +9,9 @@
 	<div
 		class="menu-icon yt-icon-container yt-icon ytmusic-toggle-menu-service-item-renderer"
 	>
-		<svg
-			viewBox="0 0 24 24"
-			preserveAspectRatio="xMidYMid meet"
-			focusable="false"
-			class="style-scope yt-icon"
-			style="pointer-events: none; display: block; width: 100%; height: 100%;"
-		>
-			<g class="style-scope yt-icon">
-				<path
-					d="M25.462,19.105v6.848H4.515v-6.848H0.489v8.861c0,1.111,0.9,2.012,2.016,2.012h24.967c1.115,0,2.016-0.9,2.016-2.012v-8.861H25.462z"
-					class="style-scope yt-icon"
-				/>
-				<path
-					d="M14.62,18.426l-5.764-6.965c0,0-0.877-0.828,0.074-0.828s3.248,0,3.248,0s0-0.557,0-1.416c0-2.449,0-6.906,0-8.723c0,0-0.129-0.494,0.615-0.494c0.75,0,4.035,0,4.572,0c0.536,0,0.524,0.416,0.524,0.416c0,1.762,0,6.373,0,8.742c0,0.768,0,1.266,0,1.266s1.842,0,2.998,0c1.154,0,0.285,0.867,0.285,0.867s-4.904,6.51-5.588,7.193C15.092,18.979,14.62,18.426,14.62,18.426z"
-					class="style-scope yt-icon"
-				/>
-			</g>
-		</svg>
+		<svg id="SvgjsSvg1001" width="288" height="288" xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svgjs="http://svgjs.com/svgjs"><defs id="SvgjsDefs1002"></defs><g id="SvgjsG1008" transform="matrix(0.9167,0,0,0.9167,11.995200000000011,11.995200000000011)"><svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 512 512" viewBox="0 0 512 512" width="288" height="288"><path d="M382.56,233.376C379.968,227.648,374.272,224,368,224h-64V16c0-8.832-7.168-16-16-16h-64c-8.832,0-16,7.168-16,16v208h-64
+			c-6.272,0-11.968,3.68-14.56,9.376c-2.624,5.728-1.6,12.416,2.528,17.152l112,128c3.04,3.488,7.424,5.472,12.032,5.472
+			c4.608,0,8.992-2.016,12.032-5.472l112-128C384.192,245.824,385.152,239.104,382.56,233.376z" fill="#aaaaaa" class="color000 svgShape"></path><path d="M432,352v96H80v-96H16v128c0,17.696,14.336,32,32,32h416c17.696,0,32-14.304,32-32V352H432z" fill="#aaaaaa" class="color000 svgShape"></path></svg></g></svg>
 	</div>
 	<div
 		class="text style-scope ytmusic-toggle-menu-service-item-renderer"


### PR DESCRIPTION
Current download icon: 
![image](https://user-images.githubusercontent.com/23726813/113469187-510b9300-9411-11eb-937d-bc90c5433e83.png)

With pull request:
![image](https://user-images.githubusercontent.com/23726813/113469320-4998b980-9412-11eb-81fc-3e65416203c5.png)


The only thing that changed was adding `fill="#aaaaaa"`