### PR TITLE
Interactive notifications for windows

### DIFF
--- a/config/defaults.js
+++ b/config/defaults.js
@@ -45,7 +45,7 @@ const defaultConfig = {
 			enabled: false,
 			urgency: "normal",
 			unpauseNotification: false,
-			interactive: true
+			interactive: true //has effect only on Windows 8+
 		}
 	},
 };

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -44,7 +44,8 @@ const defaultConfig = {
 		notifications: {
 			enabled: false,
 			urgency: "normal",
-			unpauseNotification: false
+			unpauseNotification: false,
+			interactive: true
 		}
 	},
 };

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -45,7 +45,7 @@ const defaultConfig = {
 			enabled: false,
 			urgency: "normal",
 			unpauseNotification: false,
-			interactive: true //has effect only on Windows 8+
+			interactive: false //has effect only on Windows 8+
 		}
 	},
 };

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -43,9 +43,9 @@ const defaultConfig = {
 		},
 		notifications: {
 			enabled: false,
-			urgency: "normal",
 			unpauseNotification: false,
-			interactive: false //has effect only on Windows 8+
+			urgency: "normal", //has effect only on Linux 
+			interactive: false //has effect only on Windows
 		}
 	},
 };

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
 		"electron-updater": "^4.3.6",
 		"filenamify": "^4.2.0",
 		"node-fetch": "^2.6.1",
+		"node-notifier": "^9.0.1",
 		"ytdl-core": "^4.4.5",
 		"ytpl": "^2.0.5"
 	},

--- a/plugins/notifications/back.js
+++ b/plugins/notifications/back.js
@@ -3,7 +3,7 @@ const is = require("electron-is");
 const getSongInfo = require("../../providers/song-info");
 const { notificationImage } = require("./utils");
 
-const { setup, notifyInteractive } = require("./interactive")
+const { setupInteractive, notifyInteractive } = require("./interactive")
 
 const notify = (info, options) => {
 
@@ -24,9 +24,10 @@ const notify = (info, options) => {
 };
 
 module.exports = (win, options) => {
+	const isInteractive = is.windows() && options.interactive;
 	//setup interactive notifications for windows
-	if (is.windows()) {
-		setup(win);
+	if (isInteractive) {
+		setupInteractive(win);
 	}
 	const registerCallback = getSongInfo(win);
 	let oldNotification;
@@ -45,7 +46,7 @@ module.exports = (win, options) => {
 			// If url isn"t the same as last one - send notification
 			if (songInfo.url !== oldURL) {
 				oldURL = songInfo.url;
-				if (is.windows() && options.interactive) {
+				if (isInteractive) {
 					notifyInteractive(songInfo);
 				} else {
 					// Close the old notification

--- a/plugins/notifications/back.js
+++ b/plugins/notifications/back.js
@@ -32,7 +32,7 @@ module.exports = (win, options) => {
 	const registerCallback = getSongInfo(win);
 	let oldNotification;
 	let oldURL = "";
-	win.on("ready-to-show", () => {
+	win.once("ready-to-show", () => {
 		// Register the callback for new song information
 		registerCallback(songInfo => {
 			// on pause - reset url? and skip notification

--- a/plugins/notifications/back.js
+++ b/plugins/notifications/back.js
@@ -43,7 +43,7 @@ module.exports = (win, options) => {
 				}
 				return;
 			}
-			// If url isn"t the same as last one - send notification
+			// If url isn't the same as last one - send notification
 			if (songInfo.url !== oldURL) {
 				oldURL = songInfo.url;
 				if (isInteractive) {

--- a/plugins/notifications/back.js
+++ b/plugins/notifications/back.js
@@ -27,7 +27,7 @@ module.exports = (win, options) => {
 	const isInteractive = is.windows() && options.interactive;
 	//setup interactive notifications for windows
 	if (isInteractive) {
-		setupInteractive(win);
+		setupInteractive(win, options.unpauseNotification);
 	}
 	const registerCallback = getSongInfo(win);
 	let oldNotification;

--- a/plugins/notifications/interactive.js
+++ b/plugins/notifications/interactive.js
@@ -1,4 +1,3 @@
-const is = require("electron-is");
 const { notificationImage, icons } = require("./utils");
 const getSongControls = require('../../providers/song-controls');
 const notifier = require("node-notifier");
@@ -57,7 +56,6 @@ module.exports.notifyInteractive = function sendToaster(songInfo) {
     notifier.notify(
         toDelete,
         (err, data) => {
-            console.log("clicked "+data);
             // Will also wait until notification is closed.
             if (err) {
                 console.log(`ERROR = ${err}\n DATA = ${data}`);

--- a/plugins/notifications/interactive.js
+++ b/plugins/notifications/interactive.js
@@ -1,0 +1,96 @@
+const is = require("electron-is");
+const { app } = require("electron");
+const { notificationImage, icons } = require("./utils");
+const getSongControls = require('../../providers/song-controls');
+const notifier = require("node-notifier");
+
+const appID = "com.github.th-ch.youtube-music";
+const shortcutPath = `("Youtube Music" "${app.getPath("exe")}" "${appID}")`;
+
+//saving controls here avoid errors
+let controls;
+
+//delete old notification
+let toDelete;
+function Delete() {
+    if (toDelete === undefined) {
+        return;
+    }
+    const removeNotif = Object.assign(toDelete, {
+        remove: toDelete.id
+    })
+    notifier.notify(removeNotif)
+
+    toDelete = undefined;
+}
+
+//Setup on launch
+module.exports.setup = (win) => {
+    //save controls
+    const { playPause, next, previous } = getSongControls(win);
+    controls = { playPause, next, previous };
+    //setup global listeners
+    notifier.on("dismissed", () => { Delete(); });
+    notifier.on("timeout", () => { Delete(); });
+    //try installing shortcut
+    if (!is.dev()) {
+        notifier.notify({
+            title: "installing shortcut",
+            id: 1337,
+            install: shortcutPath
+        });
+    }
+
+    //close all listeners on close
+    win.on("closed", () => {
+        notifier.removeAllListeners();
+    });
+}
+
+//New notification
+module.exports.notifyInteractive = function sendToaster(songInfo) {
+    Delete();
+    //download image and get path
+    let imgSrc = notificationImage(songInfo, true);
+    toDelete = {
+        appID: !is.dev() ? appID : undefined, //(will break action buttons if not installed to start menu)
+        title: songInfo.title || "Playing",
+        message: songInfo.artist,
+        id: parseInt(Math.random() * 1000000, 10),
+        icon: imgSrc,
+        actions: [
+            icons.previous, // Previous
+            songInfo.isPaused ? icons.play : icons.pause,
+            icons.next // Next
+        ],
+        sound: false,
+    };
+    //send notification
+    notifier.notify(
+        toDelete,
+        (err, data) => {
+            // Will also wait until notification is closed.
+            if (err) {
+                console.log(`ERROR = ${err}\n DATA = ${data}`);
+            }
+            switch (data) {
+                case icons.previous.normalize():
+                    controls.previous();
+                    return;
+                case icons.next.normalize():
+                    controls.next();
+                    return;
+                case icons.play.normalize():
+                    controls.playPause();
+                    toDelete = undefined; // dont delete notification on play/pause
+                    return;
+                case icons.pause.normalize():
+                    controls.playPause();
+                    songInfo.isPaused = true;
+                    toDelete = undefined; // it gets deleted automatically
+                    sendToaster(songInfo);
+            }
+        }
+
+    );
+}

--- a/plugins/notifications/interactive.js
+++ b/plugins/notifications/interactive.js
@@ -1,13 +1,9 @@
 const is = require("electron-is");
-const { app } = require("electron");
 const { notificationImage, icons } = require("./utils");
 const getSongControls = require('../../providers/song-controls');
 const notifier = require("node-notifier");
 
-const appID = "com.github.th-ch.youtube-music";
-const shortcutPath = `("Youtube Music" "${app.getPath("exe")}" "${appID}")`;
-
-//saving controls here avoid errors
+//store song controls
 let controls;
 
 //delete old notification
@@ -32,16 +28,8 @@ module.exports.setup = (win) => {
     //setup global listeners
     notifier.on("dismissed", () => { Delete(); });
     notifier.on("timeout", () => { Delete(); });
-    //try installing shortcut
-    if (!is.dev()) {
-        notifier.notify({
-            title: "installing shortcut",
-            id: 1337,
-            install: shortcutPath
-        });
-    }
 
-    //close all listeners on close
+    //remove all listeners on close
     win.on("closed", () => {
         notifier.removeAllListeners();
     });
@@ -53,7 +41,7 @@ module.exports.notifyInteractive = function sendToaster(songInfo) {
     //download image and get path
     let imgSrc = notificationImage(songInfo, true);
     toDelete = {
-        appID: !is.dev() ? appID : undefined, //(will break action buttons if not installed to start menu)
+        //app id undefined - will break buttons
         title: songInfo.title || "Playing",
         message: songInfo.artist,
         id: parseInt(Math.random() * 1000000, 10),
@@ -69,6 +57,7 @@ module.exports.notifyInteractive = function sendToaster(songInfo) {
     notifier.notify(
         toDelete,
         (err, data) => {
+            console.log("clicked "+data);
             // Will also wait until notification is closed.
             if (err) {
                 console.log(`ERROR = ${err}\n DATA = ${data}`);

--- a/plugins/notifications/interactive.js
+++ b/plugins/notifications/interactive.js
@@ -4,14 +4,14 @@ const notifier = require("node-notifier");
 
 //store song controls reference on launch
 let controls;
-let NotificationOnPause;
+let notificationOnPause;
 
 //Save controls and onPause option
 module.exports.setupInteractive = (win, unpauseNotification) => {
     const { playPause, next, previous } = getSongControls(win);
     controls = { playPause, next, previous };
 
-    NotificationOnPause = unpauseNotification;
+    notificationOnPause = unpauseNotification;
 
     win.webContents.once("closed", () => {
         deleteNotification()
@@ -71,7 +71,7 @@ module.exports.notifyInteractive = function sendToaster(songInfo) {
                     // dont delete notification on play/pause
                     toDelete = undefined;
                     //manually send notification if not sending automatically
-                    if (!NotificationOnPause) {
+                    if (!notificationOnPause) {
                         songInfo.isPaused = false;
                         sendToaster(songInfo);
                     }

--- a/plugins/notifications/interactive.js
+++ b/plugins/notifications/interactive.js
@@ -12,6 +12,10 @@ module.exports.setupInteractive = (win, unpauseNotification) => {
     controls = { playPause, next, previous };
 
     onPause = unpauseNotification;
+
+    win.webContents.on("closed", () => {
+        Delete()
+    });
 }
 
 //delete old notification

--- a/plugins/notifications/interactive.js
+++ b/plugins/notifications/interactive.js
@@ -4,14 +4,14 @@ const notifier = require("node-notifier");
 
 //store song controls reference on launch
 let controls;
-let onPause;
+let NotificationOnPause;
 
 //Save controls and onPause option
 module.exports.setupInteractive = (win, unpauseNotification) => {
     const { playPause, next, previous } = getSongControls(win);
     controls = { playPause, next, previous };
 
-    onPause = unpauseNotification;
+    NotificationOnPause = unpauseNotification;
 
     win.webContents.once("closed", () => {
         deleteNotification()
@@ -22,6 +22,7 @@ module.exports.setupInteractive = (win, unpauseNotification) => {
 let toDelete;
 function deleteNotification() {
     if (toDelete !== undefined) {
+        // To remove the notification it has to be done this way
         const removeNotif = Object.assign(toDelete, {
             remove: toDelete.id
         })
@@ -70,7 +71,7 @@ module.exports.notifyInteractive = function sendToaster(songInfo) {
                     // dont delete notification on play/pause
                     toDelete = undefined;
                     //manually send notification if not sending automatically
-                    if (!onPause) {
+                    if (!NotificationOnPause) {
                         songInfo.isPaused = false;
                         sendToaster(songInfo);
                     }

--- a/plugins/notifications/interactive.js
+++ b/plugins/notifications/interactive.js
@@ -13,7 +13,7 @@ module.exports.setupInteractive = (win, unpauseNotification) => {
 
     onPause = unpauseNotification;
 
-    win.webContents.on("closed", () => {
+    win.webContents.once("closed", () => {
         Delete()
     });
 }

--- a/plugins/notifications/interactive.js
+++ b/plugins/notifications/interactive.js
@@ -20,7 +20,7 @@ module.exports.setupInteractive = (win, unpauseNotification) => {
 
 //delete old notification
 let toDelete;
-function Delete() {
+function deleteNotification() {
     if (toDelete !== undefined) {
         const removeNotif = Object.assign(toDelete, {
             remove: toDelete.id

--- a/plugins/notifications/interactive.js
+++ b/plugins/notifications/interactive.js
@@ -14,7 +14,7 @@ module.exports.setupInteractive = (win, unpauseNotification) => {
     onPause = unpauseNotification;
 
     win.webContents.once("closed", () => {
-        Delete()
+        deleteNotification()
     });
 }
 
@@ -33,7 +33,7 @@ function deleteNotification() {
 
 //New notification
 module.exports.notifyInteractive = function sendToaster(songInfo) {
-    Delete();
+    deleteNotification();
     //download image and get path
     let imgSrc = notificationImage(songInfo, true);
     toDelete = {
@@ -84,7 +84,7 @@ module.exports.notifyInteractive = function sendToaster(songInfo) {
                 //Native datatype
                 case "dismissed":
                 case "timeout":
-                    Delete();
+                    deleteNotification();
             }
         }
 

--- a/plugins/notifications/interactive.js
+++ b/plugins/notifications/interactive.js
@@ -29,12 +29,9 @@ function Delete() {
 
 //New notification
 module.exports.notifyInteractive = function sendToaster(songInfo) {
-    console.log("called toaster");
     Delete();
-    console.log("deleted");
     //download image and get path
     let imgSrc = notificationImage(songInfo, true);
-    console.log("got image");
     toDelete = {
         //app id undefined - will break buttons
         title: songInfo.title || "Playing",
@@ -42,20 +39,19 @@ module.exports.notifyInteractive = function sendToaster(songInfo) {
         id: parseInt(Math.random() * 1000000, 10),
         icon: imgSrc,
         actions: [
-            icons.previous, // Previous
+            icons.previous,
             songInfo.isPaused ? icons.play : icons.pause,
-            icons.next // Next
+            icons.next
         ],
         sound: false,
     };
-    console.log("sending notification");
     //send notification
     notifier.notify(
         toDelete,
         (err, data) => {
             // Will also wait until notification is closed.
             if (err) {
-                console.log(`ERROR = ${err}\n DATA = ${data}`);
+                console.log(`ERROR = ${err.toString()}\n DATA = ${data}`);
             }
             switch (data) {
                 //buttons
@@ -68,7 +64,7 @@ module.exports.notifyInteractive = function sendToaster(songInfo) {
                 case icons.play.normalize():
                     controls.playPause();
                     // dont delete notification on play/pause
-                    toDelete = undefined; 
+                    toDelete = undefined;
                     //manually send notification if not sending automatically
                     if (!onPause) {
                         songInfo.isPaused = false;

--- a/plugins/notifications/menu.js
+++ b/plugins/notifications/menu.js
@@ -1,4 +1,4 @@
-const { urgencyLevels, setUrgency, setUnpause, setInteractive } = require("./utils");
+const { urgencyLevels, setOption } = require("./utils");
 const is = require("electron-is");
 
 module.exports = (win, options) => [
@@ -8,21 +8,21 @@ module.exports = (win, options) => [
 			label: level.name,
 			type: "radio",
 			checked: options.urgency === level.value,
-			click: () => setUrgency(options, level.value)
+			click: () => setOption(options, "urgency", level.value)
 		})),
 	},
 	{
 		label: "Show notification on unpause",
 		type: "checkbox",
 		checked: options.unpauseNotification,
-		click: (item) => setUnpause(options, item.checked)
+		click: (item) => setOption(options, "unpauseNotification", item.checked)
 	},
 	...(is.windows() ?
 		[{
 			label: "Interactive Notifications",
 			type: "checkbox",
 			checked: options.interactive,
-			click: (item) => setInteractive(options, item.checked)
+			click: (item) => setOption(options, "interactive", item.checked)
 		}] :
 		[])
 ];

--- a/plugins/notifications/menu.js
+++ b/plugins/notifications/menu.js
@@ -1,4 +1,5 @@
-const {urgencyLevels, setUrgency, setUnpause} = require("./utils");
+const {urgencyLevels, setUrgency, setUnpause, setInteractive} = require("./utils");
+const is = require("electron-is");
 
 module.exports = (win, options) => [
 	{
@@ -15,5 +16,13 @@ module.exports = (win, options) => [
 		type: "checkbox",
 		checked: options.unpauseNotification,
 		click: (item) => setUnpause(options, item.checked)
-	}
+	},
+	...(is.windows() ?
+		[{
+			label: "Interactive",
+			type: "checkbox",
+			checked: options.interactive,
+			click: (item) => setInteractive(options, item.checked)
+		}] :
+		[])
 ];

--- a/plugins/notifications/menu.js
+++ b/plugins/notifications/menu.js
@@ -1,4 +1,4 @@
-const {urgencyLevels, setUrgency, setUnpause, setInteractive} = require("./utils");
+const { urgencyLevels, setUrgency, setUnpause, setInteractive } = require("./utils");
 const is = require("electron-is");
 
 module.exports = (win, options) => [

--- a/plugins/notifications/menu.js
+++ b/plugins/notifications/menu.js
@@ -2,21 +2,17 @@ const { urgencyLevels, setOption } = require("./utils");
 const is = require("electron-is");
 
 module.exports = (win, options) => [
-	{
-		label: "Notification Priority",
-		submenu: urgencyLevels.map(level => ({
-			label: level.name,
-			type: "radio",
-			checked: options.urgency === level.value,
-			click: () => setOption(options, "urgency", level.value)
-		})),
-	},
-	{
-		label: "Show notification on unpause",
-		type: "checkbox",
-		checked: options.unpauseNotification,
-		click: (item) => setOption(options, "unpauseNotification", item.checked)
-	},
+	...(is.linux() ?
+		[{
+			label: "Notification Priority",
+			submenu: urgencyLevels.map(level => ({
+				label: level.name,
+				type: "radio",
+				checked: options.urgency === level.value,
+				click: () => setOption(options, "urgency", level.value)
+			})),
+		}] :
+		[]),
 	...(is.windows() ?
 		[{
 			label: "Interactive Notifications",
@@ -24,5 +20,11 @@ module.exports = (win, options) => [
 			checked: options.interactive,
 			click: (item) => setOption(options, "interactive", item.checked)
 		}] :
-		[])
+		[]),
+	{
+		label: "Show notification on unpause",
+		type: "checkbox",
+		checked: options.unpauseNotification,
+		click: (item) => setOption(options, "unpauseNotification", item.checked)
+	},
 ];

--- a/plugins/notifications/menu.js
+++ b/plugins/notifications/menu.js
@@ -19,7 +19,7 @@ module.exports = (win, options) => [
 	},
 	...(is.windows() ?
 		[{
-			label: "Interactive",
+			label: "Interactive Notifications",
 			type: "checkbox",
 			checked: options.interactive,
 			click: (item) => setInteractive(options, item.checked)

--- a/plugins/notifications/utils.js
+++ b/plugins/notifications/utils.js
@@ -1,19 +1,57 @@
-const {setOptions} = require("../../config/plugins");
+const { setOptions } = require("../../config/plugins");
+const path = require("path");
+const { app } = require("electron");
+const icon = path.join(__dirname, "assets", "youtube-music.png");
+const fs = require("fs");
+
+const tempIcon = path.join(app.getPath("userData"), "tempIcon.png");
 
 module.exports.urgencyLevels = [
-	{name: "Low", value: "low"},
-	{name: "Normal", value: "normal"},
-	{name: "High", value: "critical"},
+	{ name: "Low", value: "low" },
+	{ name: "Normal", value: "normal" },
+	{ name: "High", value: "critical" },
 ];
 module.exports.setUrgency = (options, level) => {
-	options.urgency = level
-	setOption(options)
+	options.urgency = level;
+	setOption(options);
 };
 module.exports.setUnpause = (options, value) => {
-	options.unpauseNotification = value
-	setOption(options)
+	options.unpauseNotification = value;
+	setOption(options);
+};
+module.exports.setInteractive = (options, value) => {
+	options.interactive = value;
+	setOption(options);
+}
+
+module.exports.notificationImage = function (songInfo, url = false) {
+	//return local url
+	if (!!songInfo && url) {
+		try {
+			fs.writeFileSync(tempIcon,
+				songInfo.image
+					.resize({ height: 256, width: 256 })
+					.toPNG()
+			);
+		} catch (err) {
+			console.log(`Error downloading song icon:\n${err.toString()}`)
+			return icon;
+		}
+		return tempIcon;
+	}
+	//else: return image
+	return songInfo.image
+		? songInfo.image.resize({ height: 256, width: 256 })
+		: icon
 };
 
 let setOption = options => {
 	setOptions("notifications", options)
 };
+
+module.exports.icons = {
+	play: "\u{1405}", // ᐅ
+	pause: "\u{2016}", // ‖
+	next: "\u{1433}", // ᐳ
+	previous: "\u{1438}" // ᐸ
+}

--- a/plugins/notifications/utils.js
+++ b/plugins/notifications/utils.js
@@ -1,9 +1,9 @@
 const { setOptions } = require("../../config/plugins");
 const path = require("path");
 const { app } = require("electron");
-const icon = path.join(__dirname, "assets", "youtube-music.png");
 const fs = require("fs");
 
+const icon = "assets/youtube-music.png";
 const tempIcon = path.join(app.getPath("userData"), "tempIcon.png");
 
 module.exports.urgencyLevels = [

--- a/plugins/notifications/utils.js
+++ b/plugins/notifications/utils.js
@@ -6,52 +6,51 @@ const fs = require("fs");
 const icon = "assets/youtube-music.png";
 const tempIcon = path.join(app.getPath("userData"), "tempIcon.png");
 
+module.exports.icons = {
+	play: "\u{1405}", // ᐅ
+	pause: "\u{2016}", // ‖
+	next: "\u{1433}", // ᐳ
+	previous: "\u{1438}" // ᐸ
+}
+
+module.exports.setOption = (options, option, value) => {
+	options[option] = value;
+	setOptions("notifications", options)
+}
+
 module.exports.urgencyLevels = [
 	{ name: "Low", value: "low" },
 	{ name: "Normal", value: "normal" },
 	{ name: "High", value: "critical" },
 ];
-module.exports.setUrgency = (options, level) => {
-	options.urgency = level;
-	setOption(options);
-};
-module.exports.setUnpause = (options, value) => {
-	options.unpauseNotification = value;
-	setOption(options);
-};
-module.exports.setInteractive = (options, value) => {
-	options.interactive = value;
-	setOption(options);
-}
 
 module.exports.notificationImage = function (songInfo, saveIcon = false) {
 	//return local path to temp icon
 	if (saveIcon && !!songInfo.image) {
 		try {
 			fs.writeFileSync(tempIcon,
-				songInfo.image
-					.resize({ height: 256, width: 256 })
+				centerNativeImage(songInfo.image)
 					.toPNG()
 			);
 		} catch (err) {
-			console.log(`Error downloading song icon:\n${err.toString()}`)
+			console.log(`Error writing song icon to disk:\n${err.toString()}`)
 			return icon;
 		}
 		return tempIcon;
 	}
 	//else: return image
 	return songInfo.image
-		? songInfo.image.resize({ height: 256, width: 256 })
+		? centerNativeImage(songInfo.image)
 		: icon
 };
 
-let setOption = options => {
-	setOptions("notifications", options)
-};
+function centerNativeImage(nativeImage) {
+	const tempImage = nativeImage.resize({ height: 256 });
+	const margin = Math.max((tempImage.getSize().width - 256), 0);
 
-module.exports.icons = {
-	play: "\u{1405}", // ᐅ
-	pause: "\u{2016}", // ‖
-	next: "\u{1433}", // ᐳ
-	previous: "\u{1438}" // ᐸ
+	return tempImage.crop({
+		x: Math.round(margin / 2),
+		y: 0,
+		width: 256, height: 256
+	})
 }

--- a/plugins/notifications/utils.js
+++ b/plugins/notifications/utils.js
@@ -24,9 +24,9 @@ module.exports.setInteractive = (options, value) => {
 	setOption(options);
 }
 
-module.exports.notificationImage = function (songInfo, url = false) {
-	//return local url
-	if (!!songInfo && url) {
+module.exports.notificationImage = function (songInfo, saveIcon = false) {
+	//return local path to temp icon
+	if (saveIcon && !!songInfo.image) {
 		try {
 			fs.writeFileSync(tempIcon,
 				songInfo.image

--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -46,6 +46,9 @@ const handleData = async (responseText, win) => {
 	let data = JSON.parse(responseText);
 	songInfo.title = data?.videoDetails?.title;
 	songInfo.artist = data?.videoDetails?.author;
+	if (songInfo.artist.endsWith(" - Topic")) {
+		songInfo.artist = songInfo.artist.slice(0, -8);
+	}
 	songInfo.views = data?.videoDetails?.viewCount;
 	songInfo.imageSrc = data?.videoDetails?.thumbnail?.thumbnails?.pop()?.url;
 	songInfo.songDuration = data?.videoDetails?.lengthSeconds;

--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -28,6 +28,18 @@ const getPausedStatus = async (win) => {
 	return !title.includes("-");
 };
 
+const getArtist = async (win) => {
+	return await win.webContents.executeJavaScript(
+		`
+		var bar = document.getElementsByClassName('subtitle ytmusic-player-bar')[0];
+		var artistName = (bar.getElementsByClassName('yt-formatted-string')[0]) || (bar.getElementsByClassName('byline ytmusic-player-bar')[0]);
+		if (artistName) {
+			artistName.textContent;
+		}
+		`
+	)
+}
+
 // Fill songInfo with empty values
 const songInfo = {
 	title: "",
@@ -45,10 +57,7 @@ const songInfo = {
 const handleData = async (responseText, win) => {
 	let data = JSON.parse(responseText);
 	songInfo.title = data?.videoDetails?.title;
-	songInfo.artist = data?.videoDetails?.author;
-	if (songInfo.artist.endsWith(" - Topic")) {
-		songInfo.artist = songInfo.artist.slice(0, -8);
-	}
+	songInfo.artist = await getArtist(win) || data?.videoDetails?.author;
 	songInfo.views = data?.videoDetails?.viewCount;
 	songInfo.imageSrc = data?.videoDetails?.thumbnail?.thumbnails?.pop()?.url;
 	songInfo.songDuration = data?.videoDetails?.lengthSeconds;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6335,6 +6335,18 @@ node-notifier@^8.0.0:
     uuid "^8.3.0"
     which "^2.0.2"
 
+node-notifier@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-9.0.1.tgz#cea837f4c5e733936c7b9005e6545cea825d1af4"
+  integrity sha512-fPNFIp2hF/Dq7qLDzSg4vZ0J4e9v60gJR+Qx7RbjbWqzPDdEqeVpEx5CFeDAELIl+A/woaaNn1fQ5nEVerMxJg==
+  dependencies:
+    growly "^1.3.0"
+    is-wsl "^2.2.0"
+    semver "^7.3.2"
+    shellwords "^0.1.1"
+    uuid "^8.3.0"
+    which "^2.0.2"
+
 noop-logger@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"


### PR DESCRIPTION
## This PR adds an option to 'notifications' plugin (only on windows)
> Currently looks like this:
![2-2](https://user-images.githubusercontent.com/78568641/114102651-63ce0e00-98d0-11eb-9dfe-c5a02bb54f9c.png)

----

> Could be changed to 2nd option which might be better:
![1-1](https://user-images.githubusercontent.com/78568641/114102726-83653680-98d0-11eb-8c95-182df239a451.png)
Unicode: [`\u{2770}`-previous]  [`\u{25B6}`-play] [`\u{2771}`-next]
(would need a subtle change of code since output for that play button [뿯▽] isn't the same as input for some reason)

----

The same lib could be used to setup interactive notification for mac, if anyone wants to work on that - [Node Notifier](https://www.npmjs.com/package/node-notifier)

- The standard pause button unicode wasn't used, because windows render those media buttons as blue

- Because of a bug with the delivery method, appID cannot be set without breaking the button functionality 
 (it makes returned `data` equal `undefined`)
so appID will it will always be the default "SnoreToast".

### Misc: 
>  This PR also changes things for both notifications (normal ones too):

 - Song Icon is resized and cropped to keep original aspect ratio (resizing was really ugly with wide images before)

- Made `Notification Priority` menu item show only on linux (since it works only on linux)

- SongInfoProvider was parsing artist name based on video request , not on song - resulting in buggy artist names.
  changed it scrape artist name from playbar (native artist name)
  - could move functionality to notifications plugin instead of infoProvider
  - could be tweaked to wait a second on first run (first song always returns old VideoArtistName because playBar hasn't loaded by the time it queries it)

- `win.once()` instead of `win.on` fix multiple callbacks being registered