### PR TITLE
[Plugin] Precise volume control

### DIFF
--- a/config/defaults.js
+++ b/config/defaults.js
@@ -45,6 +45,12 @@ const defaultConfig = {
 			enabled: false,
 			urgency: "normal",
 			unpauseNotification: false
+		},
+		"precise-volume": {
+			enabled: false,
+			steps: 1, //percentage of volume to change
+			arrowsShortcut: true, //enable ArrowUp + ArrowDown local shortcuts
+			savedVolume: undefined //plugin save volume between session here
 		}
 	},
 };

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -50,6 +50,11 @@ const defaultConfig = {
 			enabled: false,
 			steps: 1, //percentage of volume to change
 			arrowsShortcut: true, //enable ArrowUp + ArrowDown local shortcuts
+			globalShortcuts: {
+				enabled: false, // enable global shortcuts
+				volumeUp: "Shift+PageUp", // Keybind default can be changed
+				volumeDown: "Shift+PageDown"
+			},
 			savedVolume: undefined //plugin save volume between session here
 		}
 	},

--- a/plugins/precise-volume/back.js
+++ b/plugins/precise-volume/back.js
@@ -1,12 +1,12 @@
 /*
-this is used to determine if plugin is actually active
+This is used to determine if plugin is actually active
 (not if its only enabled in options)
 */
 let enabled = false;
-module.exports = (win,options) => {
-    enabled = true;
+module.exports = () => {
+	enabled = true;
 };
 
 module.exports.enabled = () => {
-    return enabled;
+	return enabled;
 };

--- a/plugins/precise-volume/back.js
+++ b/plugins/precise-volume/back.js
@@ -7,8 +7,9 @@ let enabled = false;
 module.exports = (win) => {
 	enabled = true;
 
-	//did-finish-load is called after DOMContentLoaded.
-	//thats the reason the timing is controlled from main
+	// youtube-music register some of the target listeners after DOMContentLoaded
+	// did-finish-load is called after all elements finished loading, including said listeners
+	// Thats the reason the timing is controlled from main
 	win.webContents.once("did-finish-load", () => {
 		win.webContents.send("restoreAddEventListener");
 	});

--- a/plugins/precise-volume/back.js
+++ b/plugins/precise-volume/back.js
@@ -3,8 +3,15 @@ This is used to determine if plugin is actually active
 (not if its only enabled in options)
 */
 let enabled = false;
-module.exports = () => {
+
+module.exports = (win) => {
 	enabled = true;
+
+	//did-finish-load is called after DOMContentLoaded.
+	//thats the reason the timing is controlled from main
+	win.webContents.once("did-finish-load", () => {
+		win.webContents.send("restoreAddEventListener");
+	});
 };
 
 module.exports.enabled = () => {

--- a/plugins/precise-volume/back.js
+++ b/plugins/precise-volume/back.js
@@ -1,0 +1,12 @@
+/*
+this is used to determine if plugin is actually active
+(not if its only enabled in options)
+*/
+let enabled = false;
+module.exports = (win,options) => {
+    enabled = true;
+};
+
+module.exports.enabled = () => {
+    return enabled;
+};

--- a/plugins/precise-volume/back.js
+++ b/plugins/precise-volume/back.js
@@ -1,3 +1,5 @@
+const { isEnabled } = require("../../config/plugins");
+
 /*
 This is used to determine if plugin is actually active
 (not if its only enabled in options)
@@ -12,6 +14,7 @@ module.exports = (win) => {
 	// Thats the reason the timing is controlled from main
 	win.webContents.once("did-finish-load", () => {
 		win.webContents.send("restoreAddEventListener");
+		win.webContents.send("setupVideoPlayerVolumeMousewheel", !isEnabled("hide-video-player"));
 	});
 };
 

--- a/plugins/precise-volume/front.js
+++ b/plugins/precise-volume/front.js
@@ -1,6 +1,6 @@
 const { ipcRenderer } = require("electron");
 const { setOptions } = require("../../config/plugins");
- 
+
 function $(selector) { return document.querySelector(selector); }
 
 module.exports = (options) => {
@@ -54,7 +54,7 @@ function setPlaybarOnwheel(options) {
 function changeVolume(increase, options) {
 	// Need to change both the actual volume and the slider
 	const videoStream = $(".video-stream");
-
+	const slider = $("#volume-slider");
 	// Apply volume change if valid
 	const steps = options.steps / 100;
 	videoStream.volume = increase ?
@@ -64,9 +64,11 @@ function changeVolume(increase, options) {
 	// Save the new volume
 	saveVolume(toPercent(videoStream.volume), options);
 	// Slider value automatically rounds to multiples of 5
-	$("#volume-slider").value = options.savedVolume;
-	// Finally change tooltip to new value
+	slider.value = options.savedVolume;
+	// Change tooltips to new value
 	setTooltip(options.savedVolume);
+	// Show volume slider on volume change
+	slider.classList.add("on-hover")
 }
 
 // Save volume + Update the volume tooltip when volume-slider is manually changed

--- a/plugins/precise-volume/front.js
+++ b/plugins/precise-volume/front.js
@@ -24,7 +24,6 @@ function firstRun(options) {
 	const slider = $("#volume-slider");
 	// Those elements load abit after DOMContentLoaded
 	if (videoStream && slider) {
-
 		// Set saved volume IF it pass checks
 		if (options.savedVolume
 			&& options.savedVolume >= 0 && options.savedVolume <= 100
@@ -68,7 +67,7 @@ function changeVolume(increase, options) {
 	// Change tooltips to new value
 	setTooltip(options.savedVolume);
 	// Show volume slider on volume change
-	slider.classList.add("on-hover")
+	slider.classList.add("on-hover");
 }
 
 // Save volume + Update the volume tooltip when volume-slider is manually changed
@@ -95,7 +94,7 @@ function setupSliderObserver(options) {
 // Set new volume as tooltip for volume slider and icon + expanding slider (appears when window size is small)
 const tooltipTargets = [
 	"#volume-slider",
-	"tp-yt-paper-icon-button.volume.style-scope.ytmusic-player-bar",
+	"tp-yt-paper-icon-button.volume",
 	"#expand-volume-slider",
 	"#expand-volume"
 ];

--- a/plugins/precise-volume/front.js
+++ b/plugins/precise-volume/front.js
@@ -1,12 +1,17 @@
 const { setOptions } = require("../../config/plugins");
 const { ipcRenderer } = require("electron");
+function $(selector){ return document.querySelector(selector); }
 
 module.exports = (options) => {
 	setPlaybarOnwheel(options);
-	setupObserver(options);
+	setupSliderObserver(options);
 	setupArrowShortcuts(options);
 	firstRun(options);
 };
+
+function toPercent(volume) {
+	return Math.round(Number.parseFloat(volume) * 100);
+}
 
 function saveVolume(volume, options) {
 	options.savedVolume = volume;
@@ -14,11 +19,11 @@ function saveVolume(volume, options) {
 }
 
 function firstRun(options) {
-	const videoStream = document.querySelector(".video-stream");
-	const slider = document.querySelector("#volume-slider");
-
+	const videoStream = $(".video-stream");
+	const slider = $("#volume-slider");
+	// Those elements load abit after DOMContentLoaded
 	if (videoStream && slider) {
-		// Set saved volume if it pass checks
+		// Set saved volume IF it pass checks
 		if (options.savedVolume
 			&& options.savedVolume >= 0 && options.savedVolume <= 100
 			&& Math.abs(slider.value - options.savedVolume) < 5
@@ -27,7 +32,6 @@ function firstRun(options) {
 			videoStream.volume = options.savedVolume / 100;
 			slider.value = options.savedVolume;
 		}
-
 		// Set current volume as tooltip
 		setTooltip(toPercent(videoStream.volume));
 	} else {
@@ -37,11 +41,65 @@ function firstRun(options) {
 
 function setPlaybarOnwheel(options) {
 	// Add onwheel event to play bar
-	document.querySelector("ytmusic-player-bar").onwheel = event => {
+	$("ytmusic-player-bar").onwheel = event => {
 		event.preventDefault();
-		// Event.deltaY < 0 => wheel up
+		// Event.deltaY < 0 means wheel-up
 		changeVolume(event.deltaY < 0, options);
 	};
+}
+
+// (increase = false) means volume decrease
+function changeVolume(increase, options) {
+	// Need to change both the actual volume and the slider
+	const videoStream = $(".video-stream");
+	
+	// Apply volume change if valid
+	const steps = options.steps / 100;
+	videoStream.volume = increase ?
+		Math.min(videoStream.volume + steps, 1) :
+		Math.max(videoStream.volume - steps, 0);
+
+	// Save the new volume
+	saveVolume(toPercent(videoStream.volume), options);
+	// Slider value automatically rounds to multiples of 5
+	$("#volume-slider").value = options.savedVolume;
+	// Finally change tooltip to new value
+	setTooltip(options.savedVolume);
+}
+
+// Save volume + Update the volume tooltip when volume-slider is manually changed
+function setupSliderObserver(options) {
+	const sliderObserver = new MutationObserver(mutations => {
+		for (const mutation of mutations) {
+			// This checks that volume-slider was manually set
+			if (mutation.oldValue !== mutation.target.value &&
+				(!options.savedVolume || Math.abs(options.savedVolume - mutation.target.value) > 4)) {
+				// Diff>4 means it was manually set
+				setTooltip(mutation.target.value);
+				saveVolume(mutation.target.value, options);
+			}
+		}
+	});
+
+	// Observing only changes in 'value' of volume-slider
+	sliderObserver.observe($("#volume-slider"), {
+		attributeFilter: ["value"],
+		attributeOldValue: true
+	});
+}
+
+// Set new volume as tooltip for volume slider and icon + expanding slider (appears when window size is small)
+const tooltipTargets = [
+	"#volume-slider",
+	"tp-yt-paper-icon-button.volume.style-scope.ytmusic-player-bar",
+	"#expand-volume-slider",
+	"#expand-volume"
+];
+
+function setTooltip(volume) {
+	for (target of tooltipTargets) {
+		$(target).title =  `${volume}%`;
+	}
 }
 
 function setupArrowShortcuts(options) {
@@ -51,10 +109,10 @@ function setupArrowShortcuts(options) {
 	}
 
 	// Change options from renderer to keep sync
-	ipcRenderer.on("setArrowsShortcut", (event, isEnabled) => {
+	ipcRenderer.on("setArrowsShortcut", (_event, isEnabled) => {
 		options.arrowsShortcut = isEnabled;
 		setOptions("precise-volume", options);
-		// Can setting without restarting app
+		// This allows changing setting without restarting app
 		if (isEnabled) {
 			addListener();
 		} else {
@@ -72,71 +130,12 @@ function setupArrowShortcuts(options) {
 
 	function callback(event) {
 		switch (event.code) {
-			case `ArrowUp`:
+			case "ArrowUp":
 				changeVolume(true, options);
 				break;
-			case `ArrowDown`:
+			case "ArrowDown":
 				changeVolume(false, options);
 				break;
 		}
 	}
-}
-
-function changeVolume(increase, options) {
-	// Need to change both the slider and the actual volume
-	const videoStream = document.querySelector(".video-stream");
-	const slider = document.querySelector("#volume-slider");
-	
-	// Apply volume change if valid
-	const steps = options.steps / 100;
-	videoStream.volume = increase ?
-		Math.min(videoStream.volume + steps, 1) :
-		Math.max(videoStream.volume - steps, 0);
-
-	// Save the new volume
-	saveVolume(toPercent(videoStream.volume), options);
-	// Slider value automatically rounds to multiples of 5
-	slider.value = options.savedVolume;
-	// Finally change tooltip to new value
-	setTooltip(options.savedVolume);
-}
-
-// Save volume + Update the volume tooltip when volume-slider is manually changed
-function setupObserver(options) {
-	const observer = new MutationObserver(mutations => {
-		for (const mutation of mutations) {
-			// This checks that volume-slider was manually set
-			if (mutation.oldValue !== mutation.target.value &&
-				(!options.savedVolume || Math.abs(options.savedVolume - mutation.target.value) > 4)) {
-				// Diff>4 means it was manually set
-				setTooltip(mutation.target.value);
-				saveVolume(mutation.target.value, options);
-			}
-		}
-	});
-
-	// Observing only changes in 'value' of volume-slider
-	observer.observe(document.querySelector("#volume-slider"), {
-		attributeFilter: ["value"],
-		attributeOldValue: true
-	});
-}
-
-// Set new volume as tooltip for volume slider and icon + expanding slider (appears when window size is small)
-const tooltipTargets = [
-	"#volume-slider",
-	"tp-yt-paper-icon-button.volume.style-scope.ytmusic-player-bar",
-	"#expand-volume-slider",
-	"#expand-volume"
-];
-
-function setTooltip(volume) {
-	const tooltip = volume + "%";
-	for (target of tooltipTargets) {
-		document.querySelector(target).title = tooltip;
-	}
-}
-
-function toPercent(volume) {
-	return Math.round(Number.parseFloat(volume) * 100);
 }

--- a/plugins/precise-volume/front.js
+++ b/plugins/precise-volume/front.js
@@ -7,19 +7,19 @@ module.exports = () => {
 function setFirstTooltip() {
 	const videoStream = document.querySelector(".video-stream");
 	if (videoStream?.volume) {
-		setTooltip(Math.round(parseFloat(videoStream.volume) * 100));
+		setTooltip(toPercent(videoStream.volume));
 	} else {
 		setTimeout(setFirstTooltip, 500); // Try again in 500 milliseconds
 	}
 }
 
 function setPlaybarOnwheel() {
-	// Add onwheel event to play bar
-	document.querySelector("ytmusic-player-bar").onwheel = event => {
-		event.preventDefault();
-		// Event.deltaY < 0 => wheel up
-		changeVolume(event.deltaY < 0);
-	};
+    // Add onwheel event to play bar
+    document.querySelector("ytmusic-player-bar").onwheel = event => {
+        event.preventDefault();
+        // Event.deltaY < 0 => wheel up
+        changeVolume(event.deltaY < 0);
+    };
 }
 
 // The last volume set by changeVolume() is stored here
@@ -29,13 +29,14 @@ function changeVolume(increase) {
 	// Need to change both the slider and the actual volume
 	const videoStream = document.querySelector(".video-stream");
 	const slider = document.querySelector("#volume-slider");
-	// Get the volume diff to apply
-	const diff = increase ?
-		(videoStream.volume < 1 ? 0.01 : 0) :
-		(videoStream.volume > 0 ? -0.01 : 0);
-	// Apply on both elements and save the new volume
-	videoStream.volume += diff;
-	newVolume = Math.round(Number.parseFloat(videoStream.volume) * 100);
+
+	// Apply volume change if valid
+	videoStream.volume = increase ?
+		Math.min(videoStream.volume + 0.01, 1) :
+		Math.max(videoStream.volume - 0.01, 0);
+
+	// Save the new volume
+	newVolume = toPercent(videoStream.volume);
 	// Slider value automatically rounds to multiples of 5
 	slider.value = newVolume;
 	// Finally change tooltip to new value
@@ -62,14 +63,22 @@ function setObserver() {
 	});
 }
 
+// Set new volume as tooltip for volume slider and icon + expanding slider (appears when window size is small)
+const tooltipTargets = [
+	"#volume-slider",
+	"tp-yt-paper-icon-button.volume.style-scope.ytmusic-player-bar",
+	"#expand-volume-slider",
+	"#expand-volume"
+];
+
 function setTooltip(newValue) {
 	newValue += "%";
-	// Set new volume as tooltip for volume slider and icon
-	document.querySelector("#volume-slider").title = newValue;
-	document.querySelector("tp-yt-paper-icon-button.volume.style-scope.ytmusic-player-bar").title = newValue;
-
-	// Also for expanding slider (appears when window size is small)
-	const expandingSlider = document.querySelector("#expanding-menu");
-	expandingSlider.querySelector("#expand-volume-slider").title = newValue;
-	expandingSlider.querySelector("#expand-volume").title = newValue;
+	for (target of tooltipTargets) {
+		document.querySelector(target).title = newValue;
+	}
 }
+
+function toPercent(volume) {
+	return Math.round(Number.parseFloat(volume) * 100);
+}
+

--- a/plugins/precise-volume/front.js
+++ b/plugins/precise-volume/front.js
@@ -16,11 +16,11 @@ module.exports = (options) => {
 
 function setupVideoPlayerOnwheel(options){
 	// Add onwheel event to video player
-	$("#main-panel").onwheel = event => {
+	$("#main-panel").addEventListener("wheel", event => {
 		event.preventDefault();
 		// Event.deltaY < 0 means wheel-up
 		changeVolume(event.deltaY < 0, options);
-	};
+	});
 }
 
 function toPercent(volume) {
@@ -56,11 +56,11 @@ function firstRun(options) {
 function setupPlaybar(options) {
 	const playerbar = $("ytmusic-player-bar");
 	// Add onwheel event to play bar
-	playerbar.onwheel = event => {
+	playerbar.addEventListener("wheel", event => {
 		event.preventDefault();
 		// Event.deltaY < 0 means wheel-up
 		changeVolume(event.deltaY < 0, options);
-	};
+	});
 
 	// Keep track of mouse position for showVolumeSlider()
 	playerbar.addEventListener("mouseenter", () => {

--- a/plugins/precise-volume/front.js
+++ b/plugins/precise-volume/front.js
@@ -1,0 +1,74 @@
+module.exports = () => {
+    setupPlaybarOnwheel();
+    setupObserver();
+    firstTooltip();
+}
+
+function firstTooltip () {  
+    const videoStream = document.querySelector(".video-stream");
+    if (videoStream) {
+        setTooltip(Math.round(parseFloat(videoStream.volume) * 100));
+    } else {
+      setTimeout(firstTooltip, 500); // try again in 500 milliseconds
+    }
+  }
+
+function setupPlaybarOnwheel() {
+    //add onwheel event to play bar
+    document.querySelector("ytmusic-player-bar").onwheel = (event) => {
+        event.preventDefault();
+        //event.deltaY < 0 => wheel up
+        changeVolume(event.deltaY < 0)
+    }
+}
+
+let newVolume;
+
+
+function changeVolume(increase) {
+    //need to change both the slider and the actual volume
+    const videoStream = document.querySelector(".video-stream");
+    const slider = document.querySelector("#volume-slider");
+    //get the volume diff to apply
+    const diff = increase
+        ? videoStream.volume < 1 ? 0.01 : 0
+        : videoStream.volume > 0 ? -0.01 : 0
+    //apply on both elements and save the new volume
+    videoStream.volume += diff;
+    newVolume = Math.round(parseFloat(videoStream.volume) * 100);
+    slider.value = newVolume;
+    //finally change tooltip to new value
+    setTooltip(newVolume)
+}
+
+//observer sets the tooltip when volume is manually changed
+function setupObserver() {
+    const observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+            //this checks that the new volume was manually set (without the new changeVolume() function)
+            if (mutation.oldValue !== mutation.target.value
+                && (!newVolume || Math.abs(newVolume - mutation.target.value) > 4)) {
+                //if diff>4 -> it was manually set, so update tooltip accordingly
+                setTooltip(mutation.target.value);
+            }
+        }
+    });
+
+    //observing only changes in value of volume-slider
+    observer.observe(document.querySelector("#volume-slider"), {
+        attributeFilter: ["value"],
+        attributeOldValue: true,
+    });
+}
+
+function setTooltip(newValue) {
+    newValue += "%";
+    //set new volume as tooltip for volume slider and icon
+    document.querySelector("#volume-slider").title = newValue;
+    document.querySelector("tp-yt-paper-icon-button.volume.style-scope.ytmusic-player-bar").title = newValue;
+
+    //also for expanding slider (appears when window size is small)
+    let expandingSlider = document.querySelector("#expanding-menu");
+    expandingSlider.querySelector("#expand-volume-slider").title = newValue;
+    expandingSlider.querySelector("#expand-volume").title = newValue;
+}

--- a/plugins/precise-volume/front.js
+++ b/plugins/precise-volume/front.js
@@ -17,6 +17,7 @@ module.exports = (options) => {
 	}
 
 	firstRun(options);
+
 	// This way the ipc listener gets cleared either way
 	ipcRenderer.once("setupVideoPlayerVolumeMousewheel", (_event, toEnable) => {
 		if (toEnable)
@@ -24,8 +25,8 @@ module.exports = (options) => {
 	});
 };
 
+/** Add onwheel event to video player */
 function setupVideoPlayerOnwheel(options) {
-	// Add onwheel event to video player
 	$("#main-panel").addEventListener("wheel", event => {
 		event.preventDefault();
 		// Event.deltaY < 0 means wheel-up
@@ -42,6 +43,7 @@ function saveVolume(volume, options) {
 	setOptions("precise-volume", options);
 }
 
+/** Restore saved volume and setup tooltip */
 function firstRun(options) {
 	const videoStream = $(".video-stream");
 	const slider = $("#volume-slider");
@@ -63,9 +65,10 @@ function firstRun(options) {
 	}
 }
 
+/** Add onwheel event to play bar and also track if play bar is hovered*/
 function setupPlaybar(options) {
 	const playerbar = $("ytmusic-player-bar");
-	// Add onwheel event to play bar
+
 	playerbar.addEventListener("wheel", event => {
 		event.preventDefault();
 		// Event.deltaY < 0 means wheel-up
@@ -82,7 +85,7 @@ function setupPlaybar(options) {
 	});
 }
 
-// (increase = false) means volume decrease
+/** if (toIncrease = false) then volume decrease */
 function changeVolume(toIncrease, options) {
 	// Need to change both the actual volume and the slider
 	const videoStream = $(".video-stream");
@@ -121,7 +124,7 @@ function showVolumeSlider(slider) {
 	}, 3000);
 }
 
-// Save volume + Update the volume tooltip when volume-slider is manually changed
+/** Save volume + Update the volume tooltip when volume-slider is manually changed */
 function setupSliderObserver(options) {
 	const sliderObserver = new MutationObserver(mutations => {
 		for (const mutation of mutations) {
@@ -166,7 +169,6 @@ function setupGlobalShortcuts(options) {
 }
 
 function setupLocalArrowShortcuts(options) {
-	// Register shortcuts if enabled
 	if (options.arrowsShortcut) {
 		addListener();
 	}
@@ -175,7 +177,7 @@ function setupLocalArrowShortcuts(options) {
 	ipcRenderer.on("setArrowsShortcut", (_event, isEnabled) => {
 		options.arrowsShortcut = isEnabled;
 		setOptions("precise-volume", options);
-		// This allows changing setting without restarting app
+		// This allows changing this setting without restarting app
 		if (isEnabled) {
 			addListener();
 		} else {

--- a/plugins/precise-volume/front.js
+++ b/plugins/precise-volume/front.js
@@ -1,74 +1,75 @@
 module.exports = () => {
-    setupPlaybarOnwheel();
-    setupObserver();
-    firstTooltip();
+	setPlaybarOnwheel();
+	setObserver();
+	setFirstTooltip();
+};
+
+function setFirstTooltip() {
+	const videoStream = document.querySelector(".video-stream");
+	if (videoStream?.volume) {
+		setTooltip(Math.round(parseFloat(videoStream.volume) * 100));
+	} else {
+		setTimeout(setFirstTooltip, 500); // Try again in 500 milliseconds
+	}
 }
 
-function firstTooltip() {
-    const videoStream = document.querySelector(".video-stream");
-    if (videoStream) {
-        setTooltip(Math.round(parseFloat(videoStream.volume) * 100));
-    } else {
-        setTimeout(firstTooltip, 500); // try again in 500 milliseconds
-    }
+function setPlaybarOnwheel() {
+	// Add onwheel event to play bar
+	document.querySelector("ytmusic-player-bar").onwheel = event => {
+		event.preventDefault();
+		// Event.deltaY < 0 => wheel up
+		changeVolume(event.deltaY < 0);
+	};
 }
 
-function setupPlaybarOnwheel() {
-    //add onwheel event to play bar
-    document.querySelector("ytmusic-player-bar").onwheel = (event) => {
-        event.preventDefault();
-        //event.deltaY < 0 => wheel up
-        changeVolume(event.deltaY < 0)
-    }
-}
-
-//the last volume set by changeVolume() is stored here
-let newVolume; //used to determine if volume-slider was manually moved 
+// The last volume set by changeVolume() is stored here
+let newVolume; // Used to determine if volume-slider was manually moved
 
 function changeVolume(increase) {
-    //need to change both the slider and the actual volume
-    const videoStream = document.querySelector(".video-stream");
-    const slider = document.querySelector("#volume-slider");
-    //get the volume diff to apply
-    const diff = increase
-        ? videoStream.volume < 1 ? 0.01 : 0
-        : videoStream.volume > 0 ? -0.01 : 0
-    //apply on both elements and save the new volume
-    videoStream.volume += diff;
-    newVolume = Math.round(parseFloat(videoStream.volume) * 100);
-    slider.value = newVolume;
-    //finally change tooltip to new value
-    setTooltip(newVolume)
+	// Need to change both the slider and the actual volume
+	const videoStream = document.querySelector(".video-stream");
+	const slider = document.querySelector("#volume-slider");
+	// Get the volume diff to apply
+	const diff = increase ?
+		(videoStream.volume < 1 ? 0.01 : 0) :
+		(videoStream.volume > 0 ? -0.01 : 0);
+	// Apply on both elements and save the new volume
+	videoStream.volume += diff;
+	newVolume = Math.round(Number.parseFloat(videoStream.volume) * 100);
+	// Slider value automatically rounds to multiples of 5
+	slider.value = newVolume;
+	// Finally change tooltip to new value
+	setTooltip(newVolume);
 }
 
-//update the volume tooltip when volume-slider is manually changed
-function setupObserver() {
-    const observer = new MutationObserver((mutations) => {
-        for (const mutation of mutations) {
-            //this checks that volume-slider was manually set
-            if (mutation.oldValue !== mutation.target.value
-                && (!newVolume || Math.abs(newVolume - mutation.target.value) > 4)) {
-                //diff>4 means it was manually set, so update tooltip accordingly
-                setTooltip(mutation.target.value);
-            }
-        }
-    });
+// Update the volume tooltip when volume-slider is manually changed
+function setObserver() {
+	const observer = new MutationObserver(mutations => {
+		for (const mutation of mutations) {
+			// This checks that volume-slider was manually set
+			if (mutation.oldValue !== mutation.target.value &&
+                (!newVolume || Math.abs(newVolume - mutation.target.value) > 4)) {
+				// Diff>4 means it was manually set, so update tooltip accordingly
+				setTooltip(mutation.target.value);
+			}
+		}
+	});
 
-    //observing only changes in 'value' of volume-slider
-    observer.observe(document.querySelector("#volume-slider"), {
-        attributeFilter: ["value"],
-        attributeOldValue: true,
-    });
+	// Observing only changes in 'value' of volume-slider
+	observer.observe(document.querySelector("#volume-slider"), {
+		attributeFilter: ["value"],
+		attributeOldValue: true
+	});
 }
 
 function setTooltip(newValue) {
-    newValue += "%";
-    //set new volume as tooltip for volume slider and icon
-    document.querySelector("#volume-slider").title = newValue;
-    document.querySelector("tp-yt-paper-icon-button.volume.style-scope.ytmusic-player-bar").title = newValue;
+	newValue += "%";
+	// Set new volume as tooltip for volume slider and icon
+	document.querySelector("#volume-slider").title = newValue;
+	document.querySelector("tp-yt-paper-icon-button.volume.style-scope.ytmusic-player-bar").title = newValue;
 
-    //also for expanding slider (appears when window size is small)
-    let expandingSlider = document.querySelector("#expanding-menu");
-    expandingSlider.querySelector("#expand-volume-slider").title = newValue;
-    expandingSlider.querySelector("#expand-volume").title = newValue;
+	// Also for expanding slider (appears when window size is small)
+	const expandingSlider = document.querySelector("#expanding-menu");
+	expandingSlider.querySelector("#expand-volume-slider").title = newValue;
+	expandingSlider.querySelector("#expand-volume").title = newValue;
 }

--- a/plugins/precise-volume/front.js
+++ b/plugins/precise-volume/front.js
@@ -8,7 +8,20 @@ module.exports = (options) => {
 	setupSliderObserver(options);
 	setupArrowShortcuts(options);
 	firstRun(options);
+	ipcRenderer.once("setupVideoPlayerVolumeMousewheel", (_event, toEnable) => {
+		if (toEnable)
+			setupVideoPlayerOnwheel(options);
+	});
 };
+
+function setupVideoPlayerOnwheel(options){
+	// Add onwheel event to video player
+	$("#main-panel").onwheel = event => {
+		event.preventDefault();
+		// Event.deltaY < 0 means wheel-up
+		changeVolume(event.deltaY < 0, options);
+	};
+}
 
 function toPercent(volume) {
 	return Math.round(Number.parseFloat(volume) * 100);

--- a/plugins/precise-volume/front.js
+++ b/plugins/precise-volume/front.js
@@ -46,23 +46,39 @@ function setPlaybarOnwheel(options) {
 
 function setupArrowShortcuts(options) {
 	//change options from renderer to keep sync
-	ipcRenderer.on("setArrowsShortcut", (event, value) => {
-		options.arrowsShortcut = value;
+	ipcRenderer.on("setArrowsShortcut", (event, isEnabled) => {
+		options.arrowsShortcut = isEnabled;
 		setOptions("precise-volume", options);
+		//can setting without restarting app
+		if (isEnabled) {
+			addListener();
+		} else {
+			removeListener();
+		}
 	});
 
 	//register shortcuts if enabled
 	if (options.arrowsShortcut) {
-		window.addEventListener('keydown', (event) => {
-			switch (event.code) {
-				case `ArrowUp`:
-					changeVolume(true, options);
-					break;
-				case `ArrowDown`:
-					changeVolume(false, options);
-					break;
-			}
-		}, true);
+		addListener();
+	}
+
+	function addListener() {
+		window.addEventListener('keydown', callback);
+	}
+
+	function removeListener() {
+		window.removeEventListener("keydown", callback);
+	}
+
+	function callback(event) {
+		switch (event.code) {
+			case `ArrowUp`:
+				changeVolume(true, options);
+				break;
+			case `ArrowDown`:
+				changeVolume(false, options);
+				break;
+		}
 	}
 }
 

--- a/plugins/precise-volume/front.js
+++ b/plugins/precise-volume/front.js
@@ -86,11 +86,12 @@ function changeVolume(increase, options) {
 	// Need to change both the slider and the actual volume
 	const videoStream = document.querySelector(".video-stream");
 	const slider = document.querySelector("#volume-slider");
-
+	
 	// Apply volume change if valid
+	const steps = options.steps / 100;
 	videoStream.volume = increase ?
-		Math.min(videoStream.volume + 0.01, 1) :
-		Math.max(videoStream.volume - 0.01, 0);
+		Math.min(videoStream.volume + steps, 1) :
+		Math.max(videoStream.volume - steps, 0);
 
 	// Save the new volume
 	saveVolume(toPercent(videoStream.volume), options);

--- a/plugins/precise-volume/front.js
+++ b/plugins/precise-volume/front.js
@@ -13,11 +13,17 @@ function saveVolume(volume, options) {
 
 function firstRun(options) {
 	const videoStream = document.querySelector(".video-stream");
-	if (videoStream) {
-		// Set saved volume if it exists and is valid
-		if (options.savedVolume && options.savedVolume >= 0 && options.savedVolume <= 100) {
+	const slider = document.querySelector("#volume-slider");
+
+	if (videoStream && slider) {
+		// Set saved volume if it pass checks
+		if (options.savedVolume
+			&& options.savedVolume >= 0 && options.savedVolume <= 100
+			&& Math.abs(slider.value - options.savedVolume) < 5
+			// If plugin was disabled and volume changed then diff>4
+		) {
 			videoStream.volume = options.savedVolume / 100;
-			document.querySelector("#volume-slider").value = options.savedVolume;
+			slider.value = options.savedVolume;
 		}
 
 		// Set current volume as tooltip

--- a/plugins/precise-volume/front.js
+++ b/plugins/precise-volume/front.js
@@ -1,6 +1,7 @@
-const { setOptions } = require("../../config/plugins");
 const { ipcRenderer } = require("electron");
-function $(selector){ return document.querySelector(selector); }
+const { setOptions } = require("../../config/plugins");
+ 
+function $(selector) { return document.querySelector(selector); }
 
 module.exports = (options) => {
 	setPlaybarOnwheel(options);
@@ -23,6 +24,7 @@ function firstRun(options) {
 	const slider = $("#volume-slider");
 	// Those elements load abit after DOMContentLoaded
 	if (videoStream && slider) {
+
 		// Set saved volume IF it pass checks
 		if (options.savedVolume
 			&& options.savedVolume >= 0 && options.savedVolume <= 100
@@ -52,7 +54,7 @@ function setPlaybarOnwheel(options) {
 function changeVolume(increase, options) {
 	// Need to change both the actual volume and the slider
 	const videoStream = $(".video-stream");
-	
+
 	// Apply volume change if valid
 	const steps = options.steps / 100;
 	videoStream.volume = increase ?
@@ -98,7 +100,7 @@ const tooltipTargets = [
 
 function setTooltip(volume) {
 	for (target of tooltipTargets) {
-		$(target).title =  `${volume}%`;
+		$(target).title = `${volume}%`;
 	}
 }
 

--- a/plugins/precise-volume/front.js
+++ b/plugins/precise-volume/front.js
@@ -1,9 +1,11 @@
 const { setOptions } = require("../../config/plugins");
+const { ipcRenderer } = require("electron");
 
 module.exports = (options) => {
 	setPlaybarOnwheel(options);
 	setObserver(options);
 	firstRun(options);
+	setupArrowShortcuts(options);
 };
 
 function saveVolume(volume, options) {
@@ -40,6 +42,28 @@ function setPlaybarOnwheel(options) {
 		// Event.deltaY < 0 => wheel up
 		changeVolume(event.deltaY < 0, options);
 	};
+}
+
+function setupArrowShortcuts(options) {
+	//change options from renderer to keep sync
+	ipcRenderer.on("setArrowsShortcut", (event, value) => {
+		options.arrowsShortcut = value;
+		setOptions("precise-volume", options);
+	});
+
+	//register shortcuts if enabled
+	if (options.arrowsShortcut) {
+		window.addEventListener('keydown', (event) => {
+			switch (event.code) {
+				case `ArrowUp`:
+					changeVolume(true, options);
+					break;
+				case `ArrowDown`:
+					changeVolume(false, options);
+					break;
+			}
+		}, true);
+	}
 }
 
 function changeVolume(increase, options) {

--- a/plugins/precise-volume/front.js
+++ b/plugins/precise-volume/front.js
@@ -4,14 +4,14 @@ module.exports = () => {
     firstTooltip();
 }
 
-function firstTooltip () {  
+function firstTooltip() {
     const videoStream = document.querySelector(".video-stream");
     if (videoStream) {
         setTooltip(Math.round(parseFloat(videoStream.volume) * 100));
     } else {
-      setTimeout(firstTooltip, 500); // try again in 500 milliseconds
+        setTimeout(firstTooltip, 500); // try again in 500 milliseconds
     }
-  }
+}
 
 function setupPlaybarOnwheel() {
     //add onwheel event to play bar
@@ -22,8 +22,8 @@ function setupPlaybarOnwheel() {
     }
 }
 
-let newVolume;
-
+//the last volume set by changeVolume() is stored here
+let newVolume; //used to determine if volume-slider was manually moved 
 
 function changeVolume(increase) {
     //need to change both the slider and the actual volume
@@ -41,20 +41,20 @@ function changeVolume(increase) {
     setTooltip(newVolume)
 }
 
-//observer sets the tooltip when volume is manually changed
+//update the volume tooltip when volume-slider is manually changed
 function setupObserver() {
     const observer = new MutationObserver((mutations) => {
         for (const mutation of mutations) {
-            //this checks that the new volume was manually set (without the new changeVolume() function)
+            //this checks that volume-slider was manually set
             if (mutation.oldValue !== mutation.target.value
                 && (!newVolume || Math.abs(newVolume - mutation.target.value) > 4)) {
-                //if diff>4 -> it was manually set, so update tooltip accordingly
+                //diff>4 means it was manually set, so update tooltip accordingly
                 setTooltip(mutation.target.value);
             }
         }
     });
 
-    //observing only changes in value of volume-slider
+    //observing only changes in 'value' of volume-slider
     observer.observe(document.querySelector("#volume-slider"), {
         attributeFilter: ["value"],
         attributeOldValue: true,

--- a/plugins/precise-volume/front.js
+++ b/plugins/precise-volume/front.js
@@ -3,9 +3,9 @@ const { ipcRenderer } = require("electron");
 
 module.exports = (options) => {
 	setPlaybarOnwheel(options);
-	setObserver(options);
-	firstRun(options);
+	setupObserver(options);
 	setupArrowShortcuts(options);
+	firstRun(options);
 };
 
 function saveVolume(volume, options) {
@@ -45,22 +45,22 @@ function setPlaybarOnwheel(options) {
 }
 
 function setupArrowShortcuts(options) {
-	//change options from renderer to keep sync
+	// Register shortcuts if enabled
+	if (options.arrowsShortcut) {
+		addListener();
+	}
+
+	// Change options from renderer to keep sync
 	ipcRenderer.on("setArrowsShortcut", (event, isEnabled) => {
 		options.arrowsShortcut = isEnabled;
 		setOptions("precise-volume", options);
-		//can setting without restarting app
+		// Can setting without restarting app
 		if (isEnabled) {
 			addListener();
 		} else {
 			removeListener();
 		}
 	});
-
-	//register shortcuts if enabled
-	if (options.arrowsShortcut) {
-		addListener();
-	}
 
 	function addListener() {
 		window.addEventListener('keydown', callback);
@@ -101,7 +101,7 @@ function changeVolume(increase, options) {
 }
 
 // Save volume + Update the volume tooltip when volume-slider is manually changed
-function setObserver(options) {
+function setupObserver(options) {
 	const observer = new MutationObserver(mutations => {
 		for (const mutation of mutations) {
 			// This checks that volume-slider was manually set
@@ -129,14 +129,13 @@ const tooltipTargets = [
 	"#expand-volume"
 ];
 
-function setTooltip(newValue) {
-	newValue += "%";
+function setTooltip(volume) {
+	const tooltip = volume + "%";
 	for (target of tooltipTargets) {
-		document.querySelector(target).title = newValue;
+		document.querySelector(target).title = tooltip;
 	}
 }
 
 function toPercent(volume) {
 	return Math.round(Number.parseFloat(volume) * 100);
 }
-

--- a/plugins/precise-volume/front.js
+++ b/plugins/precise-volume/front.js
@@ -91,7 +91,7 @@ function changeVolume(toIncrease, options) {
 	const videoStream = $(".video-stream");
 	const slider = $("#volume-slider");
 	// Apply volume change if valid
-	const steps = options.steps / 100;
+	const steps = (options.steps || 1) / 100;
 	videoStream.volume = toIncrease ?
 		Math.min(videoStream.volume + steps, 1) :
 		Math.max(videoStream.volume - steps, 0);

--- a/plugins/precise-volume/menu.js
+++ b/plugins/precise-volume/menu.js
@@ -1,10 +1,19 @@
+const { enabled } = require("./back")
+const { setOptions } = require("../../config/plugins");
+
 module.exports = (win, options) => [
 	{
 		label: "Arrowkeys controls",
 		type: "checkbox",
 		checked: !!options.arrowsShortcut,
 		click: (item) => {
-            win.webContents.send("setArrowsShortcut", item.checked);
+            //dynamically change setting if plugin enabled
+            if (enabled()) {
+                win.webContents.send("setArrowsShortcut", item.checked);
+            } else { //fallback to usual method if disabled
+                options.arrowsShortcut = item.checked;
+                setOptions("precise-volume", options);
+            }
         }
 	}
 ];

--- a/plugins/precise-volume/menu.js
+++ b/plugins/precise-volume/menu.js
@@ -1,4 +1,4 @@
-const { enabled } = require("./back")
+const { enabled } = require("./back");
 const { setOptions } = require("../../config/plugins");
 
 module.exports = (win, options) => [
@@ -7,13 +7,13 @@ module.exports = (win, options) => [
 		type: "checkbox",
 		checked: !!options.arrowsShortcut,
 		click: (item) => {
-            //dynamically change setting if plugin enabled
-            if (enabled()) {
-                win.webContents.send("setArrowsShortcut", item.checked);
-            } else { //fallback to usual method if disabled
-                options.arrowsShortcut = item.checked;
-                setOptions("precise-volume", options);
-            }
-        }
+			// Dynamically change setting if plugin enabled
+			if (enabled()) {
+				win.webContents.send("setArrowsShortcut", item.checked);
+			} else { // Fallback to usual method if disabled
+				options.arrowsShortcut = item.checked;
+				setOptions("precise-volume", options);
+			}
+		}
 	}
 ];

--- a/plugins/precise-volume/menu.js
+++ b/plugins/precise-volume/menu.js
@@ -1,0 +1,10 @@
+module.exports = (win, options) => [
+	{
+		label: "Arrowkeys controls",
+		type: "checkbox",
+		checked: !!options.arrowsShortcut,
+		click: (item) => {
+            win.webContents.send("setArrowsShortcut", item.checked);
+        }
+	}
+];

--- a/plugins/precise-volume/preload.js
+++ b/plugins/precise-volume/preload.js
@@ -1,28 +1,28 @@
 const { ipcRenderer } = require("electron");
 
 // Override specific listeners of volume-slider by modifying Element.prototype
-function overrideAddEventListener(){
+function overrideAddEventListener() {
     // Events to ignore
     const nativeEvents = ["mousewheel", "keydown", "keyup"];
     // Save native addEventListener
-	Element.prototype._addEventListener = Element.prototype.addEventListener;
-
-	Element.prototype.addEventListener = function(type,listener,useCapture=false) {
-        if(this.tagName === "TP-YT-PAPER-SLIDER") { //tagName of #volume-slider
+    Element.prototype._addEventListener = Element.prototype.addEventListener;
+    // Override addEventListener to Ignore specific events in volume-slider
+    Element.prototype.addEventListener = function (type, listener, useCapture = false) {
+        if (this.tagName === "TP-YT-PAPER-SLIDER") { // tagName of #volume-slider
             for (const eventType of nativeEvents) {
                 if (eventType === type) {
                     return;
                 }
             }
-        } //else
-		this._addEventListener(type,listener,useCapture);
+        }//else
+        this._addEventListener(type, listener, useCapture);
     };
 }
 
 module.exports = () => {
     overrideAddEventListener();
-    // Restore the listeners after load to avoid keeping Element.prototype altered
+    // Restore original function after did-finish-load to avoid keeping Element.prototype altered
     ipcRenderer.once("restoreAddEventListener", () => { //called from Main to make sure page is completly loaded
-		Element.prototype.addEventListener = Element.prototype._addEventListener;
-	});
-}
+        Element.prototype.addEventListener = Element.prototype._addEventListener;
+    });
+};

--- a/plugins/precise-volume/preload.js
+++ b/plugins/precise-volume/preload.js
@@ -1,0 +1,28 @@
+const { ipcRenderer } = require("electron");
+
+// Override specific listeners of volume-slider by modifying Element.prototype
+function overrideAddEventListener(){
+    // Events to ignore
+    const nativeEvents = ["mousewheel", "keydown", "keyup"];
+    // Save native addEventListener
+	Element.prototype._addEventListener = Element.prototype.addEventListener;
+
+	Element.prototype.addEventListener = function(type,listener,useCapture=false) {
+        if(this.tagName === "TP-YT-PAPER-SLIDER") { //tagName of #volume-slider
+            for (const eventType of nativeEvents) {
+                if (eventType === type) {
+                    return;
+                }
+            }
+        } //else
+		this._addEventListener(type,listener,useCapture);
+    };
+}
+
+module.exports = () => {
+    overrideAddEventListener();
+    // Restore the listeners after load to avoid keeping Element.prototype altered
+    ipcRenderer.once("restoreAddEventListener", () => { //called from Main to make sure page is completly loaded
+		Element.prototype.addEventListener = Element.prototype._addEventListener;
+	});
+}

--- a/preload.js
+++ b/preload.js
@@ -1,6 +1,6 @@
 const path = require("path");
 
-const { contextBridge, remote } = require("electron");
+const { remote } = require("electron");
 
 const config = require("./config");
 const { fileExists } = require("./plugins/utils");
@@ -8,9 +8,15 @@ const { fileExists } = require("./plugins/utils");
 const plugins = config.plugins.getEnabled();
 
 plugins.forEach(([plugin, options]) => {
-	const pluginPath = path.join(__dirname, "plugins", plugin, "actions.js");
-	fileExists(pluginPath, () => {
-		const actions = require(pluginPath).actions || {};
+	const preloadPath = path.join(__dirname, "plugins", plugin, "preload.js");
+	fileExists(preloadPath, () => {
+		const run = require(preloadPath);
+		run(options);
+	});
+
+	const actionPath = path.join(__dirname, "plugins", plugin, "actions.js");
+	fileExists(actionPath, () => {
+		const actions = require(actionPath).actions || {};
 
 		// TODO: re-enable once contextIsolation is set to true
 		// contextBridge.exposeInMainWorld(plugin + "Actions", actions);


### PR DESCRIPTION
### `precise-volume` plugin

The original volume slider and shortcuts lets you control volume only in steps of 5% or 10%, 
this has always bothered me, there isn't enough control - especially around the lower percentages

So I made this small plugin to fix that (name could be changed):

### Features

* You can now have precise control over volume percentage by using mouse-wheel in play bar area (bottom bar)
each step add/subtract [1%] (default can be changed)

* Optional setting to change volume with local hotkey -  arrowkeys up/down (Like in native youtube)

* Advanced option in config to setup global hotkeys

* Advanced option to change volume steps (int 1-100 representing percentage change)
Will use prompt `type: "Counter"` to allow controlling this setting once the custom prompt from #224 gets implemented

* Plugin also makes the Volume slider + icon tooltip's always show the exact current volume percentage

* Precise volume is saved and restored between sessions

--- 

### Misc

To override the default mousewheel + arrowkey behavior of the volume bar, I had to do a trick before DOMContent loaded
(The only way to remove an eventListener created with an anonymous function is to catch it before its created)

Initially I just added the code to the main preload.js but later thought it would probably be better to enable all plugins to do some preload
so, I added an option for **Every Plugin** to add a preload.js to be executed from Renderer before DOMContent loaded

 ### Note on the *original* volume slider
 * Dragging it with the cursor still works the same way.
 * When changing the volume using this plugin - it gets **visually** updated only around every 5% volume
  For example, there is no visual difference between 5% and 7%
  (that's pretty much the main reason I added the tooltip with volume percentage)

I'm not too sure how to visually modify the slider itself without native youtube functionality breaking, if it's even possible