### PR TITLE
Implement custom-electron-prompt

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,9 @@ if (config.get("options.proxy")) {
 }
 
 // Adds debug features like hotkeys for triggering dev tools and reload
-require("electron-debug")();
+require("electron-debug")({
+	showDevTools: false, //disable automatic devTools on new window
+});
 
 // Prevent window being garbage collected
 let mainWindow;
@@ -58,7 +60,7 @@ function onClosed() {
 
 function loadPlugins(win) {
 	injectCSS(win.webContents, path.join(__dirname, "youtube-music.css"));
-	win.webContents.on("did-finish-load", () => {
+	win.webContents.once("did-finish-load", () => {
 		if (is.dev()) {
 			console.log("did finish load");
 			win.webContents.openDevTools();

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ if (config.get("options.proxy")) {
 
 // Adds debug features like hotkeys for triggering dev tools and reload
 require("electron-debug")({
-	showDevTools: false, //disable automatic devTools on new window
+	showDevTools: false //disable automatic devTools on new window
 });
 
 // Prevent window being garbage collected
@@ -154,7 +154,7 @@ function createMainWindow() {
 	return win;
 }
 
-app.on("browser-window-created", (event, win) => {
+app.once("browser-window-created", (event, win) => {
 	loadPlugins(win);
 
 	win.webContents.on("did-fail-load", () => {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
 		"YoutubeNonStop": "git://github.com/lawfx/YoutubeNonStop.git#v0.8.1",
 		"async-mutex": "^0.3.1",
 		"browser-id3-writer": "^4.4.0",
+		"custom-electron-prompt": "^1.0.2",
 		"custom-electron-titlebar": "^3.2.6",
 		"discord-rpc": "^3.2.0",
 		"downloads-folder": "^3.0.1",

--- a/plugins/in-app-menu/prompt-custom-titlebar.js
+++ b/plugins/in-app-menu/prompt-custom-titlebar.js
@@ -1,0 +1,14 @@
+const customTitlebar = require("custom-electron-titlebar");
+
+module.exports = () => {
+	const bar = new customTitlebar.Titlebar({
+		backgroundColor: customTitlebar.Color.fromHex("#050505"),
+		minimizable: false,
+		maximizable: false,
+		menu: null
+	});
+	const mainStyle = document.querySelector("#container").style;
+	mainStyle.width = "100%";
+	mainStyle.position = "fixed";
+	mainStyle.border = "unset";
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2636,6 +2636,13 @@ cssstyle@^2.2.0:
   dependencies:
     cssom "~0.3.6"
 
+custom-electron-prompt@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/custom-electron-prompt/-/custom-electron-prompt-1.0.1.tgz#6d11c6e5130a444a9425bd27864777b36f1fef11"
+  integrity sha512-ldEiZ1t3rBDOb0nfvVpxQOjWJvkkUO3B/sD9IIYr2C/VG9COkc6IJNO2E3rXMPdDDIwejXEQx3CTWp2N2d4moQ==
+  dependencies:
+    electron "^11.4.4"
+
 custom-electron-titlebar@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/custom-electron-titlebar/-/custom-electron-titlebar-3.2.6.tgz#4cd064efa5020954c09732efa8c667a7ee3636e3"
@@ -3135,6 +3142,15 @@ electron@^11.2.3:
   version "11.2.3"
   resolved "https://registry.yarnpkg.com/electron/-/electron-11.2.3.tgz#8ad1d9858436cfca0e2e5ea7fea326794ae58ebb"
   integrity sha512-6yxOc42nDAptHKNlUG/vcOh2GI9x2fqp2nQbZO0/3sz2CrwsJkwR3i3oMN9XhVJaqI7GK1vSCJz0verOkWlXcQ==
+  dependencies:
+    "@electron/get" "^1.0.1"
+    "@types/node" "^12.0.12"
+    extract-zip "^1.0.3"
+
+electron@^11.4.4:
+  version "11.4.4"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-11.4.4.tgz#d6c046dedd9e22df5f6408841c3f8ae1a1d59414"
+  integrity sha512-m52nF85VADCmL9DpzJfgmkvc9fNiGZPYwptv/4fTYrYhAMiO+hmClGMXncCoSAzoULQjl+f+0b9CY4yd6nRFlQ==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
## [**Custom Electron Prompt**](https://github.com/Araxeus/custom-electron-prompt#readme)

> I pretty much made this package to easily set settings in youtube-music

#### There are currently 4 available custom types:

- Input: Just a general text input field. 
 Currently used here for settings proxy option

- Keybind: Allow capturing single or multiple keybinds (`Electron Accelerator` format)
 Will be used for setting custom hotkeys in `precise-volume` and could also be implemented for `shortcuts` plugin

 -  Counter: Similar to input, but accept only numerical values and has [+] and [-] Buttons for ease of use
  Will be used for setting custom steps in `precise-volume`

  - Select: Create a dropdown select menu, currently no use in this app
  
----
 ### About the added Proxy Option
 - Currently just set the typed string as proxy option
 - Checbox Status is updated based on proxy status - `item.checked = input !== ""`
 - Could probably somehow add an input check to prevent locking users out of the application
  (As of now, if the proxy option is badly set - The app will crash on launch)