### PR TITLE
Fix downloader metadata

### DIFF
--- a/plugins/downloader/back.js
+++ b/plugins/downloader/back.js
@@ -1,6 +1,8 @@
+const { writeFileSync } = require("fs");
 const { join } = require("path");
 
-const { dialog } = require("electron");
+const ID3Writer = require("browser-id3-writer");
+const { dialog, ipcMain } = require("electron");
 
 const getSongInfo = require("../../providers/song-info");
 const { injectCSS, listenAction } = require("../utils");
@@ -37,6 +39,34 @@ function handle(win) {
 			default:
 				console.log("Unknown action: " + action);
 		}
+	});
+
+	ipcMain.on("add-metadata", (event, filePath, songBuffer, currentMetadata) => {
+		let fileBuffer = songBuffer;
+		const songMetadata = { ...metadata, ...currentMetadata };
+
+		try {
+			const coverBuffer = songMetadata.image.toPNG();
+			const writer = new ID3Writer(songBuffer);
+
+			// Create the metadata tags
+			writer
+				.setFrame("TIT2", songMetadata.title)
+				.setFrame("TPE1", [songMetadata.artist])
+				.setFrame("APIC", {
+					type: 3,
+					data: coverBuffer,
+					description: "",
+				});
+			writer.addTag();
+			fileBuffer = Buffer.from(writer.arrayBuffer);
+		} catch (error) {
+			sendError(win, error);
+		}
+
+		writeFileSync(filePath, fileBuffer);
+		// Notify the youtube-dl file
+		event.reply("add-metadata-done");
 	});
 }
 

--- a/plugins/downloader/front.js
+++ b/plugins/downloader/front.js
@@ -44,7 +44,7 @@ global.download = () => {
 		.getAttribute("href");
 	videoUrl = !videoUrl
 		? global.songInfo.url || window.location.href
-		: baseUrl + videoUrl;
+		: baseUrl + "/" + videoUrl;
 
 	downloadVideoToMP3(
 		videoUrl,

--- a/plugins/downloader/youtube-dl.js
+++ b/plugins/downloader/youtube-dl.js
@@ -126,6 +126,7 @@ const toMP3 = async (
 			: videoName;
 		const filename = filenamify(name + "." + extension, {
 			replacement: "_",
+			maxLength: 255,
 		});
 
 		const filePath = join(folder, subfolder, filename);

--- a/plugins/downloader/youtube-dl.js
+++ b/plugins/downloader/youtube-dl.js
@@ -1,9 +1,7 @@
 const { randomBytes } = require("crypto");
-const { writeFileSync } = require("fs");
 const { join } = require("path");
 
 const Mutex = require("async-mutex").Mutex;
-const ID3Writer = require("browser-id3-writer");
 const { ipcRenderer } = require("electron");
 const is = require("electron-is");
 const filenamify = require("filenamify");
@@ -133,29 +131,12 @@ const toMP3 = async (
 		const fileBuffer = ffmpeg.FS("readFile", safeVideoName + "." + extension);
 
 		// Add the metadata
-		try {
-			const writer = new ID3Writer(fileBuffer);
-			if (metadata.image) {
-				const coverBuffer = metadata.image.toPNG();
-
-				// Create the metadata tags
-				writer
-					.setFrame("TIT2", metadata.title)
-					.setFrame("TPE1", [metadata.artist])
-					.setFrame("APIC", {
-						type: 3,
-						data: coverBuffer,
-						description: "",
-					});
-				writer.addTag();
-			}
-
-			writeFileSync(filePath, Buffer.from(writer.arrayBuffer));
-		} catch (error) {
-			sendError(error);
-		} finally {
-			reinit();
-		}
+		sendFeedback("Adding metadata…");
+		ipcRenderer.send("add-metadata", filePath, fileBuffer, {
+			artist: metadata.artist,
+			title: metadata.title,
+		});
+		ipcRenderer.once("add-metadata-done", reinit);
 	} catch (e) {
 		sendError(e);
 	} finally {


### PR DESCRIPTION
This PR improves/fixes the downloader plugin:
- fix URL to download (cases where a `/` was missing, leading to an invalid URL - worst case, a double slash should not be an issue)
- set max file name length to 255 (was 100 previously)
- set metadata in the main process (allowing to set a cover) - current metadata is still used to have up-to-date info (only drawback, the cover is not up-to-date if the song was changed but should not be a big deal)