### PR TITLE
Update and simplify in-app-menu

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -172,19 +172,21 @@ const mainMenuTemplate = (win) => [
 						},
 					},
 					{ type: "separator" },
-					{
-						label: "Toggle DevTools",
-						// Cannot use "toggleDevTools" role in MacOS
-						click: () => {
-							const { webContents } = win;
-							if (webContents.isDevToolsOpened()) {
-								webContents.closeDevTools();
-							} else {
-								const devToolsOptions = {};
-								webContents.openDevTools(devToolsOptions);
-							}
-						},
-					},
+					is.macOS() ?
+						{
+							label: "Toggle DevTools",
+							// Cannot use "toggleDevTools" role in MacOS
+							click: () => {
+								const { webContents } = win;
+								if (webContents.isDevToolsOpened()) {
+									webContents.closeDevTools();
+								} else {
+									const devToolsOptions = {};
+									webContents.openDevTools(devToolsOptions);
+								}
+							},
+						} :
+						{ role: "toggleDevTools" },
 					{
 						label: "Edit config.json",
 						click: () => {
@@ -198,41 +200,12 @@ const mainMenuTemplate = (win) => [
 	{
 		label: "View",
 		submenu: [
-			{
-				label: "Reload",
-				click: () => {
-					win.webContents.reload();
-				},
-			},
-			{
-				label: "Force Reload",
-				click: () => {
-					win.webContents.reloadIgnoringCache();
-				},
-			},
+			{ role: "reload" },
+			{ role: "forceReload" },
 			{ type: "separator" },
-			{
-				label: "Zoom In",
-				click: () => {
-					win.webContents.setZoomLevel(
-						win.webContents.getZoomLevel() + 1
-					);
-				},
-			},
-			{
-				label: "Zoom Out",
-				click: () => {
-					win.webContents.setZoomLevel(
-						win.webContents.getZoomLevel() - 1
-					);
-				},
-			},
-			{
-				label: "Reset Zoom",
-				click: () => {
-					win.webContents.setZoomLevel(0);
-				},
-			},
+			{ role: "zoomIn" },
+			{ role: "zoomOut" },
+			{ role: "resetZoom" },
 		],
 	},
 	{
@@ -261,12 +234,7 @@ const mainMenuTemplate = (win) => [
 					app.quit();
 				},
 			},
-			{
-				label: "Quit App",
-				click: () => {
-					app.quit();
-				},
-			},
+			{ role: "quit" },
 		],
 	},
 ];

--- a/menu.js
+++ b/menu.js
@@ -11,8 +11,6 @@ const pluginEnabledMenu = (win, plugin, label = "", hasSubmenu = false) => ({
 	label: label || plugin,
 	type: "checkbox",
 	checked: config.plugins.isEnabled(plugin),
-	//Submenu check used in in-app-menu
-	hasSubmenu: hasSubmenu || undefined,
 	click: (item) => {
 		if (item.checked) {
 			config.plugins.enable(plugin);
@@ -21,6 +19,9 @@ const pluginEnabledMenu = (win, plugin, label = "", hasSubmenu = false) => ({
 		}
 		if (hasSubmenu) {
 			this.setApplicationMenu(win);
+			if (config.plugins.isEnabled("in-app-menu")) {
+				win.webContents.send("updateMenu", true);
+			}
 		}
 	},
 });

--- a/menu.js
+++ b/menu.js
@@ -10,7 +10,7 @@ const config = require("./config");
 // true only if in-app-menu was loaded on launch
 const inAppMenuActive = config.plugins.isEnabled("in-app-menu");
 
-const pluginEnabledMenu = (win, plugin, label = "", hasSubmenu = false) => ({
+const pluginEnabledMenu = (plugin, label = "", hasSubmenu = false, refreshMenu = undefined) => ({
 	label: label || plugin,
 	type: "checkbox",
 	checked: config.plugins.isEnabled(plugin),
@@ -21,223 +21,226 @@ const pluginEnabledMenu = (win, plugin, label = "", hasSubmenu = false) => ({
 			config.plugins.disable(plugin);
 		}
 		if (hasSubmenu) {
-			this.setApplicationMenu(win);
-			if (inAppMenuActive) {
-				win.webContents.send("updateMenu", true);
-			}
+			refreshMenu();
 		}
 	},
 });
 
-const mainMenuTemplate = (win) => [
-	{
-		label: "Plugins",
-		submenu: [
-			...getAllPlugins().map((plugin) => {
-				const pluginPath = path.join(__dirname, "plugins", plugin, "menu.js")
-				if (existsSync(pluginPath)) {
-					if (!config.plugins.isEnabled(plugin)) {
-						return pluginEnabledMenu(win, plugin, "", true);
+const mainMenuTemplate = (win) => {
+	const refreshMenu = () => {
+		this.setApplicationMenu(win);
+		if (inAppMenuActive) {
+			win.webContents.send("updateMenu", true);
+		}
+	}
+	return [
+		{
+			label: "Plugins",
+			submenu: [
+				...getAllPlugins().map((plugin) => {
+					const pluginPath = path.join(__dirname, "plugins", plugin, "menu.js")
+					if (existsSync(pluginPath)) {
+						if (!config.plugins.isEnabled(plugin)) {
+							return pluginEnabledMenu(plugin, "", true, refreshMenu);
+						}
+						const getPluginMenu = require(pluginPath);
+						return {
+							label: plugin,
+							submenu: [
+								pluginEnabledMenu(plugin, "Enabled", true, refreshMenu),
+								...getPluginMenu(win, config.plugins.getOptions(plugin), refreshMenu),
+							],
+						};
 					}
-					const getPluginMenu = require(pluginPath);
-					return {
-						label: plugin,
-						submenu: [
-							pluginEnabledMenu(win, plugin, "Enabled", true),
-							...getPluginMenu(win, config.plugins.getOptions(plugin), () =>
-								module.exports.setApplicationMenu(win)
-							),
-						],
-					};
-				}
 
-				return pluginEnabledMenu(win, plugin);
-			}),
-		],
-	},
-	{
-		label: "Options",
-		submenu: [
-			{
-				label: "Auto-update",
-				type: "checkbox",
-				checked: config.get("options.autoUpdates"),
-				click: (item) => {
-					config.set("options.autoUpdates", item.checked);
+					return pluginEnabledMenu(plugin);
+				}),
+			],
+		},
+		{
+			label: "Options",
+			submenu: [
+				{
+					label: "Auto-update",
+					type: "checkbox",
+					checked: config.get("options.autoUpdates"),
+					click: (item) => {
+						config.set("options.autoUpdates", item.checked);
+					},
 				},
-			},
-			{
-				label: "Resume last song when app starts",
-				type: "checkbox",
-				checked: config.get("options.resumeOnStart"),
-				click: (item) => {
-					config.set("options.resumeOnStart", item.checked);
+				{
+					label: "Resume last song when app starts",
+					type: "checkbox",
+					checked: config.get("options.resumeOnStart"),
+					click: (item) => {
+						config.set("options.resumeOnStart", item.checked);
+					},
 				},
-			},
-			...(is.windows() || is.linux()
-				? [
-					{
-						label: "Hide menu",
-						type: "checkbox",
-						checked: config.get("options.hideMenu"),
-						click: (item) => {
-							config.set("options.hideMenu", item.checked);
-						},
-					},
-				]
-				: []),
-			...(is.windows() || is.macOS()
-				? // Only works on Win/Mac
-				// https://www.electronjs.org/docs/api/app#appsetloginitemsettingssettings-macos-windows
-				[
-					{
-						label: "Start at login",
-						type: "checkbox",
-						checked: config.get("options.startAtLogin"),
-						click: (item) => {
-							config.set("options.startAtLogin", item.checked);
-						},
-					},
-				]
-				: []),
-			{
-				label: "Tray",
-				submenu: [
-					{
-						label: "Disabled",
-						type: "radio",
-						checked: !config.get("options.tray"),
-						click: () => {
-							config.set("options.tray", false);
-							config.set("options.appVisible", true);
-						},
-					},
-					{
-						label: "Enabled + app visible",
-						type: "radio",
-						checked:
-							config.get("options.tray") && config.get("options.appVisible"),
-						click: () => {
-							config.set("options.tray", true);
-							config.set("options.appVisible", true);
-						},
-					},
-					{
-						label: "Enabled + app hidden",
-						type: "radio",
-						checked:
-							config.get("options.tray") && !config.get("options.appVisible"),
-						click: () => {
-							config.set("options.tray", true);
-							config.set("options.appVisible", false);
-						},
-					},
-					{ type: "separator" },
-					{
-						label: "Play/Pause on click",
-						type: "checkbox",
-						checked: config.get("options.trayClickPlayPause"),
-						click: (item) => {
-							config.set("options.trayClickPlayPause", item.checked);
-						},
-					},
-				],
-			},
-			{ type: "separator" },
-			{
-				label: "Advanced options",
-				submenu: [
-					{
-						label: "Disable hardware acceleration",
-						type: "checkbox",
-						checked: config.get("options.disableHardwareAcceleration"),
-						click: (item) => {
-							config.set("options.disableHardwareAcceleration", item.checked);
-						},
-					},
-					{
-						label: "Restart on config changes",
-						type: "checkbox",
-						checked: config.get("options.restartOnConfigChanges"),
-						click: (item) => {
-							config.set("options.restartOnConfigChanges", item.checked);
-						},
-					},
-					{
-						label: "Reset App cache when app starts",
-						type: "checkbox",
-						checked: config.get("options.autoResetAppCache"),
-						click: (item) => {
-							config.set("options.autoResetAppCache", item.checked);
-						},
-					},
-					{ type: "separator" },
-					is.macOS() ?
+				...(is.windows() || is.linux()
+					? [
 						{
-							label: "Toggle DevTools",
-							// Cannot use "toggleDevTools" role in MacOS
-							click: () => {
-								const { webContents } = win;
-								if (webContents.isDevToolsOpened()) {
-									webContents.closeDevTools();
-								} else {
-									const devToolsOptions = {};
-									webContents.openDevTools(devToolsOptions);
-								}
+							label: "Hide menu",
+							type: "checkbox",
+							checked: config.get("options.hideMenu"),
+							click: (item) => {
+								config.set("options.hideMenu", item.checked);
 							},
-						} :
-						{ role: "toggleDevTools" },
-					{
-						label: "Edit config.json",
-						click: () => {
-							config.edit();
 						},
+					]
+					: []),
+				...(is.windows() || is.macOS()
+					? // Only works on Win/Mac
+					// https://www.electronjs.org/docs/api/app#appsetloginitemsettingssettings-macos-windows
+					[
+						{
+							label: "Start at login",
+							type: "checkbox",
+							checked: config.get("options.startAtLogin"),
+							click: (item) => {
+								config.set("options.startAtLogin", item.checked);
+							},
+						},
+					]
+					: []),
+				{
+					label: "Tray",
+					submenu: [
+						{
+							label: "Disabled",
+							type: "radio",
+							checked: !config.get("options.tray"),
+							click: () => {
+								config.set("options.tray", false);
+								config.set("options.appVisible", true);
+							},
+						},
+						{
+							label: "Enabled + app visible",
+							type: "radio",
+							checked:
+								config.get("options.tray") && config.get("options.appVisible"),
+							click: () => {
+								config.set("options.tray", true);
+								config.set("options.appVisible", true);
+							},
+						},
+						{
+							label: "Enabled + app hidden",
+							type: "radio",
+							checked:
+								config.get("options.tray") && !config.get("options.appVisible"),
+							click: () => {
+								config.set("options.tray", true);
+								config.set("options.appVisible", false);
+							},
+						},
+						{ type: "separator" },
+						{
+							label: "Play/Pause on click",
+							type: "checkbox",
+							checked: config.get("options.trayClickPlayPause"),
+							click: (item) => {
+								config.set("options.trayClickPlayPause", item.checked);
+							},
+						},
+					],
+				},
+				{ type: "separator" },
+				{
+					label: "Advanced options",
+					submenu: [
+						{
+							label: "Disable hardware acceleration",
+							type: "checkbox",
+							checked: config.get("options.disableHardwareAcceleration"),
+							click: (item) => {
+								config.set("options.disableHardwareAcceleration", item.checked);
+							},
+						},
+						{
+							label: "Restart on config changes",
+							type: "checkbox",
+							checked: config.get("options.restartOnConfigChanges"),
+							click: (item) => {
+								config.set("options.restartOnConfigChanges", item.checked);
+							},
+						},
+						{
+							label: "Reset App cache when app starts",
+							type: "checkbox",
+							checked: config.get("options.autoResetAppCache"),
+							click: (item) => {
+								config.set("options.autoResetAppCache", item.checked);
+							},
+						},
+						{ type: "separator" },
+						is.macOS() ?
+							{
+								label: "Toggle DevTools",
+								// Cannot use "toggleDevTools" role in MacOS
+								click: () => {
+									const { webContents } = win;
+									if (webContents.isDevToolsOpened()) {
+										webContents.closeDevTools();
+									} else {
+										const devToolsOptions = {};
+										webContents.openDevTools(devToolsOptions);
+									}
+								},
+							} :
+							{ role: "toggleDevTools" },
+						{
+							label: "Edit config.json",
+							click: () => {
+								config.edit();
+							},
+						},
+					]
+				},
+			],
+		},
+		{
+			label: "View",
+			submenu: [
+				{ role: "reload" },
+				{ role: "forceReload" },
+				{ type: "separator" },
+				{ role: "zoomIn" },
+				{ role: "zoomOut" },
+				{ role: "resetZoom" },
+			],
+		},
+		{
+			label: "Navigation",
+			submenu: [
+				{
+					label: "Go back",
+					click: () => {
+						if (win.webContents.canGoBack()) {
+							win.webContents.goBack();
+						}
 					},
-				]
-			},
-		],
-	},
-	{
-		label: "View",
-		submenu: [
-			{ role: "reload" },
-			{ role: "forceReload" },
-			{ type: "separator" },
-			{ role: "zoomIn" },
-			{ role: "zoomOut" },
-			{ role: "resetZoom" },
-		],
-	},
-	{
-		label: "Navigation",
-		submenu: [
-			{
-				label: "Go back",
-				click: () => {
-					if (win.webContents.canGoBack()) {
-						win.webContents.goBack();
-					}
 				},
-			},
-			{
-				label: "Go forward",
-				click: () => {
-					if (win.webContents.canGoForward()) {
-						win.webContents.goForward();
-					}
+				{
+					label: "Go forward",
+					click: () => {
+						if (win.webContents.canGoForward()) {
+							win.webContents.goForward();
+						}
+					},
 				},
-			},
-			{
-				label: "Restart App",
-				click: () => {
-					app.relaunch();
-					app.quit();
+				{
+					label: "Restart App",
+					click: () => {
+						app.relaunch();
+						app.quit();
+					},
 				},
-			},
-			{ role: "quit" },
-		],
-	},
-];
+				{ role: "quit" },
+			],
+		},
+	];
+}
 
 module.exports.mainMenuTemplate = mainMenuTemplate;
 module.exports.setApplicationMenu = (win) => {

--- a/menu.js
+++ b/menu.js
@@ -7,6 +7,9 @@ const is = require("electron-is");
 const { getAllPlugins } = require("./plugins/utils");
 const config = require("./config");
 
+// true only if in-app-menu was loaded on launch
+const inAppMenuActive = config.plugins.isEnabled("in-app-menu");
+
 const pluginEnabledMenu = (win, plugin, label = "", hasSubmenu = false) => ({
 	label: label || plugin,
 	type: "checkbox",
@@ -19,7 +22,7 @@ const pluginEnabledMenu = (win, plugin, label = "", hasSubmenu = false) => ({
 		}
 		if (hasSubmenu) {
 			this.setApplicationMenu(win);
-			if (config.plugins.isEnabled("in-app-menu")) {
+			if (inAppMenuActive) {
 				win.webContents.send("updateMenu", true);
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"YoutubeNonStop": "git://github.com/lawfx/YoutubeNonStop.git#v0.9.0",
 		"async-mutex": "^0.3.1",
 		"browser-id3-writer": "^4.4.0",
-		"custom-electron-titlebar": "^3.2.6",
+		"custom-electron-titlebar": "^3.2.7",
 		"discord-rpc": "^3.2.0",
 		"electron-debug": "^3.2.0",
 		"electron-is": "^3.0.0",

--- a/plugins/in-app-menu/front.js
+++ b/plugins/in-app-menu/front.js
@@ -10,15 +10,7 @@ module.exports = () => {
 	bar.updateTitle(" ");
 	document.title = "Youtube Music";
 
-	ipcRenderer.on("updateMenu", function (event, menu) {
-		if (menu) {
-			bar.updateMenu(remote.Menu.getApplicationMenu());
-		} else {
-			try {
-				bar.updateMenu(null);
-			} catch (e) {
-				//will always throw type error - null isn't menu, but it works
-			}
-		}
+	ipcRenderer.on("updateMenu", function (_event, showMenu) {
+		bar.updateMenu(showMenu ? remote.Menu.getApplicationMenu() : null);
 	});
 };

--- a/plugins/in-app-menu/style.css
+++ b/plugins/in-app-menu/style.css
@@ -4,11 +4,6 @@
 	font-size: 14px !important;
 }
 
-/* allow submenu's to show correctly */
-.menubar-menu-container {
-	overflow-y: visible !important;
-}
-
 /* fixes scrollbar positioning relative to nav bar  */
 #nav-bar-background.ytmusic-app-layout {
 	right: 15px !important;

--- a/tray.js
+++ b/tray.js
@@ -63,12 +63,7 @@ module.exports.setUpTray = (app, win) => {
 				app.quit();
 			},
 		},
-		{
-			label: "Quit",
-			click: () => {
-				app.quit();
-			},
-		},
+		 { role: "quit" } 
 	];
 
 	const trayMenu = Menu.buildFromTemplate(template);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2877,10 +2877,10 @@ cssstyle@^2.2.0:
   dependencies:
     cssom "~0.3.6"
 
-custom-electron-titlebar@^3.2.6:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/custom-electron-titlebar/-/custom-electron-titlebar-3.2.6.tgz#4cd064efa5020954c09732efa8c667a7ee3636e3"
-  integrity sha512-P3ZGEr0eouUHqhdBBXllpuy2bFhfSmp+32HQBPcwzujjIsUhQxQj/nCpJiFa4SUGAEp1ifu/icuZdDKNNX72Tw==
+custom-electron-titlebar@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/custom-electron-titlebar/-/custom-electron-titlebar-3.2.7.tgz#fb249d6180cbda074b1d392bea755fa0743012a8"
+  integrity sha512-KO/6e3r6YflfNUOzi5QHLwkLHBP+ICtHPo70u/kUIKR8UUkDTPb4a9i19q0uDZQcjkH6oqRvFCz9wEHeEpCgxw==
 
 dashdash@^1.12.0:
   version "1.14.1"


### PR DESCRIPTION
> Follows up the multiple fixes made from my PR's ([[1]](https://github.com/AlexTorresSk/custom-electron-titlebar/pull/148), [[2]](https://github.com/AlexTorresSk/custom-electron-titlebar/pull/150)) in custom-electron-titlebar

#### This PR remove local fixes to problems than have been solved at the source:
* No more need to override `Menu.buildFromTemplate()` to fix broken menu interactions
* Restored Menu roles (now that they've been fixed )

and more tweaks at source level (dynamic update checkbox/radio status, fixed menucontainer overflow, etc.. )

This overall boost menu responsiveness

> Was waiting for the release of custom-electron-titlebar `v3.2.7`. Current version is:  [![NPM Version](https://img.shields.io/npm/v/custom-electron-titlebar.svg)](https://npmjs.org/package/custom-electron-titlebar)



