### PR TITLE
Fix downloader metadata if not currently playing

### DIFF
--- a/config/defaults.js
+++ b/config/defaults.js
@@ -41,7 +41,6 @@ const defaultConfig = {
 			api_root: "http://ws.audioscrobbler.com/2.0/",
 			api_key: "04d76faaac8726e60988e14c105d421a", // api key registered by @semvis123
 			secret: "a5d2a36fdf64819290f6982481eaffa2",
-			suffixesToRemove: [' - Topic', 'VEVO'] // removes suffixes of the artist name, for better recognition
 		},
 		discord: {
 			enabled: false,

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
 		"YoutubeNonStop": "git://github.com/lawfx/YoutubeNonStop.git#v0.9.0",
 		"async-mutex": "^0.3.1",
 		"browser-id3-writer": "^4.4.0",
+		"chokidar": "^3.5.1",
 		"custom-electron-titlebar": "^3.2.6",
 		"discord-rpc": "^3.2.0",
 		"electron-debug": "^3.2.0",

--- a/plugins/downloader/back.js
+++ b/plugins/downloader/back.js
@@ -47,7 +47,7 @@ function handle(win) {
 		const songMetadata = { ...metadata, ...currentMetadata };
 
 		if (!songMetadata.image && songMetadata.imageSrc) {
-			songMetadata.image = await getImage(songMetadata.imageSrc)
+			songMetadata.image = await getImage(songMetadata.imageSrc);
 		}
 
 		try {

--- a/plugins/downloader/back.js
+++ b/plugins/downloader/back.js
@@ -45,9 +45,11 @@ function handle(win) {
 	ipcMain.on("add-metadata", async (event, filePath, songBuffer, currentMetadata) => {
 		let fileBuffer = songBuffer;
 		const songMetadata = { ...metadata, ...currentMetadata };
+
 		if (!songMetadata.image && songMetadata.imageSrc) {
 			songMetadata.image = await getImage(songMetadata.imageSrc)
 		}
+
 		try {
 			const coverBuffer = songMetadata.image.toPNG();
 			const writer = new ID3Writer(songBuffer);

--- a/plugins/downloader/back.js
+++ b/plugins/downloader/back.js
@@ -7,6 +7,7 @@ const { dialog, ipcMain } = require("electron");
 const getSongInfo = require("../../providers/song-info");
 const { injectCSS, listenAction } = require("../utils");
 const { ACTIONS, CHANNEL } = require("./actions.js");
+const { getImage } = require("../../providers/song-info");
 
 const sendError = (win, err) => {
 	const dialogOpts = {
@@ -41,10 +42,12 @@ function handle(win) {
 		}
 	});
 
-	ipcMain.on("add-metadata", (event, filePath, songBuffer, currentMetadata) => {
+	ipcMain.on("add-metadata", async (event, filePath, songBuffer, currentMetadata) => {
 		let fileBuffer = songBuffer;
 		const songMetadata = { ...metadata, ...currentMetadata };
-
+		if (!songMetadata.image && songMetadata.imageSrc) {
+			songMetadata.image = await getImage(songMetadata.imageSrc)
+		}
 		try {
 			const coverBuffer = songMetadata.image.toPNG();
 			const writer = new ID3Writer(songBuffer);

--- a/plugins/downloader/back.js
+++ b/plugins/downloader/back.js
@@ -51,18 +51,20 @@ function handle(win) {
 		}
 
 		try {
-			const coverBuffer = songMetadata.image.toPNG();
+			const coverBuffer = songMetadata.image ? songMetadata.image.toPNG() : null;
 			const writer = new ID3Writer(songBuffer);
 
 			// Create the metadata tags
 			writer
 				.setFrame("TIT2", songMetadata.title)
-				.setFrame("TPE1", [songMetadata.artist])
-				.setFrame("APIC", {
+				.setFrame("TPE1", [songMetadata.artist]);
+			if (coverBuffer) {
+				writer.setFrame("APIC", {
 					type: 3,
 					data: coverBuffer,
 					description: "",
 				});
+			}
 			writer.addTag();
 			fileBuffer = Buffer.from(writer.arrayBuffer);
 		} catch (error) {

--- a/plugins/downloader/front.js
+++ b/plugins/downloader/front.js
@@ -38,13 +38,18 @@ const baseUrl = defaultConfig.url;
 // contextBridge.exposeInMainWorld("downloader", {
 // 	download: () => {
 global.download = () => {
+	let metadata;
 	let videoUrl = getSongMenu()
 		.querySelector("ytmusic-menu-navigation-item-renderer")
 		.querySelector("#navigation-endpoint")
 		.getAttribute("href");
-	videoUrl = !videoUrl
-		? global.songInfo.url || window.location.href
-		: baseUrl + "/" + videoUrl;
+	if (videoUrl) {
+		videoUrl = baseUrl + "/" + videoUrl;
+		metadata = null;
+	} else {
+		videoUrl = global.songInfo.url || window.location.href;
+		metadata = global.songInfo;
+	}
 
 	downloadVideoToMP3(
 		videoUrl,
@@ -61,7 +66,7 @@ global.download = () => {
 		},
 		reinit,
 		pluginOptions,
-		global.songInfo
+		metadata
 	);
 };
 // });

--- a/plugins/downloader/front.js
+++ b/plugins/downloader/front.js
@@ -47,8 +47,8 @@ global.download = () => {
 		videoUrl = baseUrl + "/" + videoUrl;
 		metadata = null;
 	} else {
-		videoUrl = global.songInfo.url || window.location.href;
 		metadata = global.songInfo;
+		videoUrl = metadata.url || window.location.href;
 	}
 
 	downloadVideoToMP3(

--- a/plugins/downloader/menu.js
+++ b/plugins/downloader/menu.js
@@ -16,7 +16,7 @@ let downloadLabel = defaultMenuDownloadLabel;
 let metadataURL = undefined;
 let callbackIsRegistered = false;
 
-module.exports = (win, options, refreshMenu) => {
+module.exports = (win, options) => {
 	if (!callbackIsRegistered) {
 		const registerCallback = getSongInfo(win);
 		registerCallback((info) => {
@@ -36,6 +36,7 @@ module.exports = (win, options, refreshMenu) => {
 					return;
 				}
 
+				console.log("trying to get playlist ID" +playlistID);
 				const playlist = await ytpl(playlistID,
 					{ limit: options.playlistMaxItems || Infinity }
 				);

--- a/plugins/downloader/menu.js
+++ b/plugins/downloader/menu.js
@@ -35,7 +35,7 @@ module.exports = (win, options, refreshMenu) => {
 					return;
 				}
 
-				const playlist = await ytpl(playlistID);
+				const playlist = await ytpl(playlistID, { limit: Infinity });
 				const playlistTitle = playlist.title;
 
 				const folder = getFolder(options.downloadFolder);

--- a/plugins/downloader/menu.js
+++ b/plugins/downloader/menu.js
@@ -73,9 +73,8 @@ module.exports = (win, options, refreshMenu) => {
 
 				let dirWatcher = chokidar.watch(playlistFolder);
 				dirWatcher.on('add', () => {
-					console.log(`progress:${progress} + steps:${steps} = newProgress:${progress+steps}`)
 					progress += steps;
-					if (progress >= 0.999) {
+					if (progress >= 0.9999) {
 						win.setProgressBar(-1); // close progress bar
 						dirWatcher.close().then(() => dirWatcher = null);
 					} else {

--- a/plugins/downloader/menu.js
+++ b/plugins/downloader/menu.js
@@ -35,7 +35,7 @@ module.exports = (win, options, refreshMenu) => {
 					return;
 				}
 
-				const playlist = await ytpl(playlistID, 
+				const playlist = await ytpl(playlistID,
 					{ limit: options.playlistMaxItems || Infinity }
 				);
 				const playlistTitle = playlist.title;
@@ -59,6 +59,14 @@ module.exports = (win, options, refreshMenu) => {
 				downloadLabel = `Downloading "${playlistTitle}"`;
 				refreshMenu();
 
+				dialog.showMessageBox({
+					type: "info",
+					buttons: ["OK"],
+					title: "Started Download",
+					message: `Downloading Playlist "${playlistTitle}"`,
+					detail: `(${playlist.items.length} songs)`,
+				});
+
 				if (is.dev()) {
 					console.log(
 						`Downloading playlist "${playlistTitle}" (${playlist.items.length} songs)`
@@ -68,7 +76,7 @@ module.exports = (win, options, refreshMenu) => {
 				playlist.items.forEach((song) => {
 					win.webContents.send(
 						"downloader-download-playlist",
-						song,
+						song.url,
 						playlistTitle,
 						options
 					);

--- a/plugins/downloader/menu.js
+++ b/plugins/downloader/menu.js
@@ -35,7 +35,9 @@ module.exports = (win, options, refreshMenu) => {
 					return;
 				}
 
-				const playlist = await ytpl(playlistID, { limit: Infinity });
+				const playlist = await ytpl(playlistID, 
+					{ limit: options.playlistMaxItems || Infinity }
+				);
 				const playlistTitle = playlist.title;
 
 				const folder = getFolder(options.downloadFolder);
@@ -63,7 +65,7 @@ module.exports = (win, options, refreshMenu) => {
 					);
 				}
 
-				playlist.items.slice(0, options.playlistMaxItems).forEach((song) => {
+				playlist.items.forEach((song) => {
 					win.webContents.send(
 						"downloader-download-playlist",
 						song,

--- a/plugins/downloader/youtube-dl.js
+++ b/plugins/downloader/youtube-dl.js
@@ -184,19 +184,13 @@ module.exports = {
 ipcRenderer.on(
 	"downloader-download-playlist",
 	(_, url, playlistFolder, options) => {
-		const reinit = () =>
-			ipcRenderer.send("downloader-feedback", defaultMenuDownloadLabel);
-
 		downloadVideoToMP3(
 			url,
-			(feedback) => {
-				ipcRenderer.send("downloader-feedback", feedback);
-			},
+			() => {},
 			(error) => {
 				triggerAction(CHANNEL, ACTIONS.ERROR, error);
-				reinit();
 			},
-			reinit,
+			() => {},
 			options,
 			null,
 			playlistFolder

--- a/plugins/downloader/youtube-dl.js
+++ b/plugins/downloader/youtube-dl.js
@@ -152,7 +152,7 @@ const toMP3 = async (
 		ipcRenderer.send("add-metadata", filePath, fileBuffer, {
 			artist: metadata.artist,
 			title: metadata.title,
-			imageSrc: metadata.imageSrc || ""
+			imageSrc: metadata.imageSrc
 		});
 		ipcRenderer.once("add-metadata-done", reinit);
 	} catch (e) {

--- a/plugins/downloader/youtube-dl.js
+++ b/plugins/downloader/youtube-dl.js
@@ -183,12 +183,12 @@ module.exports = {
 
 ipcRenderer.on(
 	"downloader-download-playlist",
-	(_, songMetadata, playlistFolder, options) => {
+	(_, url, playlistFolder, options) => {
 		const reinit = () =>
 			ipcRenderer.send("downloader-feedback", defaultMenuDownloadLabel);
 
 		downloadVideoToMP3(
-			songMetadata.url,
+			url,
 			(feedback) => {
 				ipcRenderer.send("downloader-feedback", feedback);
 			},

--- a/plugins/downloader/youtube-dl.js
+++ b/plugins/downloader/youtube-dl.js
@@ -14,7 +14,8 @@ const ytdl = require("ytdl-core");
 
 const { triggerAction, triggerActionSync } = require("../utils");
 const { ACTIONS, CHANNEL } = require("./actions.js");
-const { defaultMenuDownloadLabel, getFolder } = require("./utils");
+const { getFolder } = require("./utils");
+const { cleanupArtistName } = require("../../providers/song-info");
 
 const { createFFmpeg } = FFmpeg;
 const ffmpeg = createFFmpeg({
@@ -23,13 +24,6 @@ const ffmpeg = createFFmpeg({
 	progress: () => {}, // console.log,
 });
 const ffmpegMutex = new Mutex();
-
-function noTopic(channelName) {
-	if (channelName && channelName.endsWith(" - Topic")) {
-		channelName = channelName.slice(0, -8);
-	}
-	return channelName;
-}
 
 const downloadVideoToMP3 = async (
 	videoUrl,
@@ -46,7 +40,7 @@ const downloadVideoToMP3 = async (
 		const info = await ytdl.getInfo(videoUrl);
 		const thumbnails = info.videoDetails?.author?.thumbnails;
 		metadata = {
-			artist: info.videoDetails?.media?.artist || noTopic(info.videoDetails?.author?.name) || "",
+			artist: info.videoDetails?.media?.artist || cleanupArtistName(info.videoDetails?.author?.name) || "",
 			title: info.videoDetails?.media?.song || info.videoDetails?.title || "",
 			imageSrc: thumbnails ? thumbnails[thumbnails.length - 1].url : ""
 		}

--- a/plugins/downloader/youtube-dl.js
+++ b/plugins/downloader/youtube-dl.js
@@ -198,7 +198,7 @@ ipcRenderer.on(
 			},
 			reinit,
 			options,
-			songMetadata,
+			null,
 			playlistFolder
 		);
 	}

--- a/plugins/last-fm/back.js
+++ b/plugins/last-fm/back.js
@@ -5,21 +5,10 @@ const { setOptions } = require('../../config/plugins');
 const getSongInfo = require('../../providers/song-info');
 const defaultConfig = require('../../config/defaults');
 
-const cleanupArtistName = (config, artist) => {
-	// removes the suffixes of the artist name for more recognition by last.fm
-	const { suffixesToRemove } = config;
-	if (suffixesToRemove === undefined) return artist;
-
-	for (suffix of suffixesToRemove) {
-		artist = artist.replace(suffix, '');
-	}
-	return artist;
-}
-
 const createFormData = params => {
 	// creates the body for in the post request
 	const formData = new URLSearchParams();
-	for (key in params) {
+	for (const key in params) {
 		formData.append(key, params[key]);
 	}
 	return formData;
@@ -28,7 +17,7 @@ const createQueryString = (params, api_sig) => {
 	// creates a querystring
 	const queryData = [];
 	params.api_sig = api_sig;
-	for (key in params) {
+	for (const key in params) {
 		queryData.push(`${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`);
 	}
 	return '?'+queryData.join('&');
@@ -37,12 +26,12 @@ const createQueryString = (params, api_sig) => {
 const createApiSig = (params, secret) => { 
 	// this function creates the api signature, see: https://www.last.fm/api/authspec
 	const keys = [];
-	for (key in params) {
+	for (const key in params) {
 		keys.push(key);
 	}
 	keys.sort();
 	let sig = '';
-	for (key of keys) {
+	for (const key of keys) {
 		if (String(key) === 'format')
 			continue
 		sig += `${key}${params[key]}`;
@@ -157,8 +146,6 @@ const lastfm = async (win, config) => {
 	registerCallback( songInfo => {
 		// set remove the old scrobble timer
 		clearTimeout(scrobbleTimer);
-		// make the artist name a bit cleaner
-		songInfo.artist = cleanupArtistName(config, songInfo.artist);
 		if (!songInfo.isPaused) {
 			setNowPlaying(songInfo, config);
 			// scrobble when the song is half way through, or has passed the 4 minute mark

--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -38,7 +38,7 @@ const getArtist = async (win) => {
 			artistName.textContent;
 		}
 		`
-	)
+	);
 }
 
 // Fill songInfo with empty values
@@ -109,7 +109,7 @@ function cleanupArtistName(artist) {
 	}
 	for (const suffix of suffixesToRemove) {
 		if (artist.endsWith(suffix)) {
-			return artist.slice(0, -suffix.length)
+			return artist.slice(0, -suffix.length);
 		}
 	}
 	return artist;

--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -58,7 +58,7 @@ const songInfo = {
 const handleData = async (responseText, win) => {
 	let data = JSON.parse(responseText);
 	songInfo.title = data.videoDetails?.media?.song || data?.videoDetails?.title;
-	songInfo.artist = data.videoDetails?.media?.artist || await getArtist(win) || data?.videoDetails?.author;
+	songInfo.artist = data.videoDetails?.media?.artist || await getArtist(win) || cleanupArtistName(data?.videoDetails?.author);
 	songInfo.views = data?.videoDetails?.viewCount;
 	songInfo.imageSrc = data?.videoDetails?.thumbnail?.thumbnails?.pop()?.url;
 	songInfo.songDuration = data?.videoDetails?.lengthSeconds;
@@ -102,5 +102,20 @@ const registerProvider = (win) => {
 	return registerCallback;
 };
 
+const suffixesToRemove = [' - Topic', 'VEVO'];
+function cleanupArtistName(artist) {
+	if (!artist) {
+		return artist;
+	}
+	for (const suffix of suffixesToRemove) {
+		if (artist.endsWith(suffix)) {
+			return artist.slice(0, -suffix.length)
+		}
+	}
+	return artist;
+}
+
 module.exports = registerProvider;
 module.exports.getImage = getImage;
+module.exports.cleanupArtistName = cleanupArtistName;
+

--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -57,8 +57,8 @@ const songInfo = {
 
 const handleData = async (responseText, win) => {
 	let data = JSON.parse(responseText);
-	songInfo.title = data?.videoDetails?.title;
-	songInfo.artist = await getArtist(win) || data?.videoDetails?.author;
+	songInfo.title = data.videoDetails?.media?.song || data?.videoDetails?.title;
+	songInfo.artist = data.videoDetails?.media?.artist || await getArtist(win) || data?.videoDetails?.author;
 	songInfo.views = data?.videoDetails?.viewCount;
 	songInfo.imageSrc = data?.videoDetails?.thumbnail?.thumbnails?.pop()?.url;
 	songInfo.songDuration = data?.videoDetails?.lengthSeconds;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1638,6 +1638,14 @@ anymatch@^3.0.3:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+anymatch@~3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
+  integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
 app-builder-bin@3.5.12:
   version "3.5.12"
   resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-3.5.12.tgz#bbe174972cc1f481f73d6d92ad47a8b4c7eb4530"
@@ -1991,6 +1999,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+binary-extensions@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
+  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
 binaryextensions@^4.15.0:
   version "4.15.0"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-4.15.0.tgz#c63a502e0078ff1b0e9b00a9f74d3c2b0f8bd32e"
@@ -2075,7 +2088,7 @@ braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@^3.0.1:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -2403,6 +2416,21 @@ charenc@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
+
+chokidar@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
+  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.3.1"
 
 chownr@^1.1.1:
   version "1.1.4"
@@ -4257,7 +4285,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@^2.1.2:
+fsevents@^2.1.2, fsevents@~2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -4367,6 +4395,13 @@ glob-parent@^5.0.0, glob-parent@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+  dependencies:
+    is-glob "^4.0.1"
+
+glob-parent@~5.1.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
@@ -4902,6 +4937,13 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
 is-buffer@^1.1.5, is-buffer@~1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -5032,7 +5074,7 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-glob@^4.0.0, is-glob@^4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
@@ -6581,7 +6623,7 @@ normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
-normalize-path@^3.0.0:
+normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -7476,6 +7518,13 @@ readdir-glob@^1.0.0:
   integrity sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==
   dependencies:
     minimatch "^3.0.4"
+
+readdirp@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
+  integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
+  dependencies:
+    picomatch "^2.2.1"
 
 redent@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
PR #221 allows downloading song that aren't playing, but the metadata wasn't captured - which also threw an error:
`"image.toPNG() is not a function"`. 
The same error was thrown once per song when downloading a playlist (since the metadata didn't contain a nativeImage)

* Error is avoided by checking if `metadata.image` exist before `writer.setFrame("APIC"...`

* Use `ytdl.getInfo(videoUrl)` to get metadata for songs that aren't playing (also for playlist-download items)
  this includes `metadata.image`

 * Allows downloading playlist of unlimited size if `options.playlistMaxItems` isn't specified. fixes #251

----

 `downloader-feedback` in `downloader/menu.js` results in constantly refreshing the menu 
```javascript
ipcMain.on("downloader-feedback", (_, feedback) => {
	downloadLabel = feedback;
	refreshMenu();
});
```
(Because every single song in the playlist sets a different label + refresh + restore original label + refresh)
This results in almost always crashing my application when I try to open the main menu while playlist is still downloading.

Instead uses the messageBox below To notify that playlist download started:

https://github.com/th-ch/youtube-music/blob/13fb686188b6a39c16e565e9b87bad14638f86ca/plugins/downloader/menu.js#L62-L68

And to update the download progress, 53bf7c5 adds a taskbar progress bar that gets updated by `chokidar` that watches the new playlist download directory