### PR TITLE
fix playPause bugs by directly playPause video element

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -5,6 +5,8 @@ const { remote } = require("electron");
 const config = require("./config");
 const { fileExists } = require("./plugins/utils");
 const setupFrontLogger = require("./providers/front-logger");
+const setupSongControl = require("./providers/song-controls-front");
+const setupSongInfo = require("./providers/song-info-front");
 
 const plugins = config.plugins.getEnabled();
 
@@ -37,8 +39,10 @@ document.addEventListener("DOMContentLoaded", () => {
 	});
 
 	// inject song-info provider
-	const songInfoProviderPath = path.join(__dirname, "providers", "song-info-front.js")
-	fileExists(songInfoProviderPath, require(songInfoProviderPath));
+	setupSongInfo();
+
+	// inject song-control provider
+	setupSongControl();
 
 	// inject front logger
 	setupFrontLogger();

--- a/providers/song-controls-front.js
+++ b/providers/song-controls-front.js
@@ -10,7 +10,11 @@ module.exports = () => {
         if (videoStream.paused) {
             videoStream.play();
         } else {
-            videoStream.yns_pause();
+            if (videoStream.yns_pause) {
+                videoStream.yns_pause();
+            } else {
+                videoStream.pause();
+            }
         }
     });
 };

--- a/providers/song-controls-front.js
+++ b/providers/song-controls-front.js
@@ -1,9 +1,7 @@
 const { ipcRenderer } = require("electron");
 
-let videoStream;
+let videoStream = document.querySelector(".video-stream");
 module.exports = () => {
-    videoStream = document.querySelector(".video-stream");
-
     ipcRenderer.on("playPause", () => {
         if (!videoStream) {
             videoStream = document.querySelector(".video-stream");

--- a/providers/song-controls-front.js
+++ b/providers/song-controls-front.js
@@ -10,11 +10,9 @@ module.exports = () => {
         if (videoStream.paused) {
             videoStream.play();
         } else {
-            if (videoStream.yns_pause) {
-                videoStream.yns_pause();
-            } else {
+            videoStream.yns_pause ?
+                videoStream.yns_pause() :
                 videoStream.pause();
-            }
         }
     });
 };

--- a/providers/song-controls-front.js
+++ b/providers/song-controls-front.js
@@ -1,0 +1,18 @@
+const { ipcRenderer } = require("electron");
+
+let videoStream;
+module.exports = () => {
+    videoStream = document.querySelector(".video-stream");
+
+    ipcRenderer.on("playPause", () => {
+        if (!videoStream) {
+            videoStream = document.querySelector(".video-stream");
+        }
+
+        if (videoStream.paused) {
+            videoStream.play();
+        } else {
+            videoStream.yns_pause();
+        }
+    });
+}

--- a/providers/song-controls-front.js
+++ b/providers/song-controls-front.js
@@ -15,4 +15,4 @@ module.exports = () => {
             videoStream.yns_pause();
         }
     });
-}
+};

--- a/providers/song-controls.js
+++ b/providers/song-controls.js
@@ -12,7 +12,7 @@ module.exports = (win) => {
 		// Playback
 		previous: () => pressKey(win, "k"),
 		next: () => pressKey(win, "j"),
-		playPause: () => pressKey(win, "space"),
+		playPause: () => win.webContents.send("playPause"),
 		like: () => pressKey(win, "_"),
 		dislike: () => pressKey(win, "+"),
 		go10sBack: () => pressKey(win, "h"),

--- a/providers/song-info-front.js
+++ b/providers/song-info-front.js
@@ -10,17 +10,16 @@ ipcRenderer.on("update-song-info", async (_, extractedSongInfo) => {
 });
 
 const injectListener = () => {
-	var oldXHR = window.XMLHttpRequest;
+	const oldXHR = window.XMLHttpRequest;
 	function newXHR() {
-		var realXHR = new oldXHR();
+		const realXHR = new oldXHR();
 		realXHR.addEventListener(
 			"readystatechange",
 			() => {
-				if (realXHR.readyState == 4 && realXHR.status == 200) {
-					if (realXHR.responseURL.includes("/player")) {
+				if (realXHR.readyState === 4 && realXHR.status === 200
+					&& realXHR.responseURL.includes("/player")) {
 						// if the request contains the song info, send the response to ipcMain
 						ipcRenderer.send("song-info-request", realXHR.responseText);
-					}
 				}
 			},
 			false


### PR DESCRIPTION
this PR makes song-controls.playPause() affect directly the video element in the page. (instead of just pressing space)
This fixes several bugs when pausing the video when it isn't focused
(from tray/taskbar/notifications)

fix #145 , fix #129

also sneaky change because of previous comments:
song-info-front is directly required instead of checking if file exist (since we already know it exist)
