### PR TITLE
remove `open` dependency from last-fm plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 	"scripts": {
 		"test": "jest",
 		"start": "electron .",
-        "start:debug": "ELECTRON_ENABLE_LOGGING=1 electron .",
+		"start:debug": "ELECTRON_ENABLE_LOGGING=1 electron .",
 		"icon": "rimraf assets/generated && electron-icon-maker --input=assets/youtube-music.png --output=assets/generated",
 		"generate:package": "node utils/generate-package-json.js",
 		"postinstall": "yarn run icon && yarn run plugins",
@@ -82,7 +82,6 @@
 		"md5": "^2.3.0",
 		"node-fetch": "^2.6.1",
 		"node-notifier": "^9.0.1",
-		"open": "^8.0.3",
 		"ytdl-core": "^4.5.0",
 		"ytpl": "^2.1.1"
 	},

--- a/plugins/last-fm/back.js
+++ b/plugins/last-fm/back.js
@@ -1,6 +1,6 @@
 const fetch = require('node-fetch');
-const { shell } = require('electron')
 const md5 = require('md5');
+const { shell } = require('electron');
 const { setOptions } = require('../../config/plugins');
 const getSongInfo = require('../../providers/song-info');
 const defaultConfig = require('../../config/defaults');

--- a/plugins/last-fm/back.js
+++ b/plugins/last-fm/back.js
@@ -1,6 +1,6 @@
 const fetch = require('node-fetch');
+const { shell } = require('electron')
 const md5 = require('md5');
-const open = require("open");
 const { setOptions } = require('../../config/plugins');
 const getSongInfo = require('../../providers/song-info');
 const defaultConfig = require('../../config/defaults');
@@ -58,7 +58,7 @@ const authenticate = async config => {
 	// asks the user for authentication
 	config.token = await createToken(config);
 	setOptions('last-fm', config);
-	open(`https://www.last.fm/api/auth/?api_key=${config.api_key}&token=${config.token}`);
+	shell.openExternal(`https://www.last.fm/api/auth/?api_key=${config.api_key}&token=${config.token}`);
 	return config;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2995,11 +2995,6 @@ defer-to-connect@^2.0.0:
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.0.tgz#83d6b199db041593ac84d781b5222308ccf4c2c1"
   integrity sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==
 
-define-lazy-prop@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
-  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
-
 define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
@@ -5005,7 +5000,7 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     is-data-descriptor "^1.0.0"
     kind-of "^6.0.2"
 
-is-docker@^2.0.0, is-docker@^2.1.1:
+is-docker@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
   integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
@@ -6769,15 +6764,6 @@ open@^7.3.0:
   dependencies:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
-
-open@^8.0.3:
-  version "8.0.5"
-  resolved "https://registry.yarnpkg.com/open/-/open-8.0.5.tgz#92ee3faafef4ddbe78006f7881572f3e81430b8f"
-  integrity sha512-hkPXCz7gijWp2GoWqsQ4O/5p7F6d5pIQ/+9NyeWG1nABJ4zvLi9kJRv1a44kVf5p13wK0WMoiRA+Xey68yOytA==
-  dependencies:
-    define-lazy-prop "^2.0.0"
-    is-docker "^2.1.1"
-    is-wsl "^2.2.0"
 
 optionator@^0.8.1:
   version "0.8.3"


### PR DESCRIPTION
Replaced by Electron's [`shell.openExternal`](https://www.electronjs.org/docs/api/shell#shellopenexternalurl-options)

Closes #261
Should also close #169