### PR TITLE
Downloader tweaks + taskbar progress bar

### DIFF
--- a/plugins/downloader/actions.js
+++ b/plugins/downloader/actions.js
@@ -2,6 +2,7 @@ const CHANNEL = "downloader";
 const ACTIONS = {
 	ERROR: "error",
 	METADATA: "metadata",
+	PROGRESS: "progress",
 };
 
 module.exports = {

--- a/plugins/downloader/back.js
+++ b/plugins/downloader/back.js
@@ -22,13 +22,13 @@ const sendError = (win, err) => {
 	dialog.showMessageBox(dialogOpts);
 };
 
-let metadata = {};
+let nowPlayingMetadata = {};
 
 function handle(win) {
 	injectCSS(win.webContents, join(__dirname, "style.css"));
 	const registerCallback = getSongInfo(win);
 	registerCallback((info) => {
-		metadata = info;
+		nowPlayingMetadata = info;
 	});
 
 	listenAction(CHANNEL, (event, action, arg) => {
@@ -37,7 +37,7 @@ function handle(win) {
 				sendError(win, arg);
 				break;
 			case ACTIONS.METADATA:
-				event.returnValue = JSON.stringify(metadata);
+				event.returnValue = JSON.stringify(nowPlayingMetadata);
 				break;
 			case ACTIONS.PROGRESS: //arg = progress
 				win.setProgressBar(arg);
@@ -50,13 +50,13 @@ function handle(win) {
 	ipcMain.on("add-metadata", async (event, filePath, songBuffer, currentMetadata) => {
 		let fileBuffer = songBuffer;
 		let songMetadata;
-		if (currentMetadata.imageSrc) { // means metadata come from ytpl.getInfo();
+		if (currentMetadata.imageSrcYTPL) { // means metadata come from ytpl.getInfo();
 			songMetadata = {
 				...currentMetadata,
-				image: cropMaxWidth(await getImage(currentMetadata.imageSrc))
+				image: cropMaxWidth(await getImage(currentMetadata.imageSrcYTPL))
 			};
 		} else {
-			songMetadata = { ...metadata, ...currentMetadata };
+			songMetadata = { ...nowPlayingMetadata, ...currentMetadata };
 		}
 
 		try {

--- a/plugins/downloader/back.js
+++ b/plugins/downloader/back.js
@@ -44,11 +44,12 @@ function handle(win) {
 
 	ipcMain.on("add-metadata", async (event, filePath, songBuffer, currentMetadata) => {
 		let fileBuffer = songBuffer;
-		const songMetadata = { ...metadata, ...currentMetadata };
 
-		if (!songMetadata.image && songMetadata.imageSrc) {
-			songMetadata.image = await getImage(songMetadata.imageSrc);
+		if (currentMetadata.imageSrc) {
+			currentMetadata.image = await getImage(currentMetadata.imageSrc);
 		}
+
+		const songMetadata = { ...metadata, ...currentMetadata };
 
 		try {
 			const coverBuffer = songMetadata.image ? songMetadata.image.toPNG() : null;

--- a/plugins/downloader/back.js
+++ b/plugins/downloader/back.js
@@ -10,7 +10,7 @@ const { cropMaxWidth } = require("./utils");
 const { ACTIONS, CHANNEL } = require("./actions.js");
 const { getImage } = require("../../providers/song-info");
 
-const sendError = (err) => {
+const sendError = (win, err) => {
 	const dialogOpts = {
 		type: "info",
 		buttons: ["OK"],
@@ -34,7 +34,7 @@ function handle(win) {
 	listenAction(CHANNEL, (event, action, arg) => {
 		switch (action) {
 			case ACTIONS.ERROR: //arg = error
-				sendError(arg);
+				sendError(win, arg);
 				break;
 			case ACTIONS.METADATA:
 				event.returnValue = JSON.stringify(metadata);
@@ -77,7 +77,7 @@ function handle(win) {
 			writer.addTag();
 			fileBuffer = Buffer.from(writer.arrayBuffer);
 		} catch (error) {
-			sendError(error);
+			sendError(win, error);
 		}
 
 		writeFileSync(filePath, fileBuffer);

--- a/plugins/downloader/back.js
+++ b/plugins/downloader/back.js
@@ -49,12 +49,13 @@ function handle(win) {
 
 	ipcMain.on("add-metadata", async (event, filePath, songBuffer, currentMetadata) => {
 		let fileBuffer = songBuffer;
-
-		if (currentMetadata.imageSrc) {
+		let songMetadata;
+		if (currentMetadata.imageSrc) { // means metadata come from ytpl.getInfo();
 			currentMetadata.image = cropMaxWidth(await getImage(currentMetadata.imageSrc));
+			songMetadata = { ...currentMetadata };
+		} else {
+			songMetadata = { ...metadata, ...currentMetadata };
 		}
-
-		const songMetadata = { ...metadata, ...currentMetadata };
 
 		try {
 			const coverBuffer = songMetadata.image ? songMetadata.image.toPNG() : null;

--- a/plugins/downloader/back.js
+++ b/plugins/downloader/back.js
@@ -51,8 +51,10 @@ function handle(win) {
 		let fileBuffer = songBuffer;
 		let songMetadata;
 		if (currentMetadata.imageSrc) { // means metadata come from ytpl.getInfo();
-			currentMetadata.image = cropMaxWidth(await getImage(currentMetadata.imageSrc));
-			songMetadata = { ...currentMetadata };
+			songMetadata = {
+				...currentMetadata,
+				image: cropMaxWidth(await getImage(currentMetadata.imageSrc))
+			};
 		} else {
 			songMetadata = { ...metadata, ...currentMetadata };
 		}

--- a/plugins/downloader/front.js
+++ b/plugins/downloader/front.js
@@ -42,9 +42,10 @@ global.download = () => {
 	triggerAction(CHANNEL, ACTIONS.PROGRESS, 2); // starts with indefinite progress bar
 	let metadata;
 	let videoUrl = getSongMenu()
-		?.querySelector('ytmusic-menu-navigation-item-renderer.iron-selected[tabindex="0"]')
-		?.querySelector("#navigation-endpoint")
+		// selector of first button which is always "Start Radio"
+		?.querySelector('ytmusic-menu-navigation-item-renderer.iron-selected[tabindex="0"] #navigation-endpoint')
 		?.getAttribute("href");
+	console.log(videoUrl)
 	if (videoUrl) {
 		videoUrl = baseUrl + "/" + videoUrl;
 		metadata = null;

--- a/plugins/downloader/front.js
+++ b/plugins/downloader/front.js
@@ -45,7 +45,6 @@ global.download = () => {
 		// selector of first button which is always "Start Radio"
 		?.querySelector('ytmusic-menu-navigation-item-renderer.iron-selected[tabindex="0"] #navigation-endpoint')
 		?.getAttribute("href");
-	console.log(videoUrl)
 	if (videoUrl) {
 		videoUrl = baseUrl + "/" + videoUrl;
 		metadata = null;

--- a/plugins/downloader/front.js
+++ b/plugins/downloader/front.js
@@ -40,9 +40,9 @@ const baseUrl = defaultConfig.url;
 global.download = () => {
 	let metadata;
 	let videoUrl = getSongMenu()
-		.querySelector("ytmusic-menu-navigation-item-renderer")
-		.querySelector("#navigation-endpoint")
-		.getAttribute("href");
+		?.querySelector('ytmusic-menu-navigation-item-renderer.iron-selected[tabindex="0"]')
+		?.querySelector("#navigation-endpoint")
+		?.getAttribute("href");
 	if (videoUrl) {
 		videoUrl = baseUrl + "/" + videoUrl;
 		metadata = null;

--- a/plugins/downloader/front.js
+++ b/plugins/downloader/front.js
@@ -25,6 +25,7 @@ const observer = new MutationObserver((mutations, observer) => {
 });
 
 const reinit = () => {
+	triggerAction(CHANNEL, ACTIONS.PROGRESS, -1); // closes progress bar
 	if (!progress) {
 		console.warn("Cannot update progress");
 	} else {
@@ -38,6 +39,7 @@ const baseUrl = defaultConfig.url;
 // contextBridge.exposeInMainWorld("downloader", {
 // 	download: () => {
 global.download = () => {
+	triggerAction(CHANNEL, ACTIONS.PROGRESS, 2); // starts with indefinite progress bar
 	let metadata;
 	let videoUrl = getSongMenu()
 		?.querySelector('ytmusic-menu-navigation-item-renderer.iron-selected[tabindex="0"]')
@@ -53,11 +55,14 @@ global.download = () => {
 
 	downloadVideoToMP3(
 		videoUrl,
-		(feedback) => {
+		(feedback, ratio = undefined) => {
 			if (!progress) {
 				console.warn("Cannot update progress");
 			} else {
 				progress.innerHTML = feedback;
+			}
+			if (ratio) {
+				triggerAction(CHANNEL, ACTIONS.PROGRESS, ratio);
 			}
 		},
 		(error) => {

--- a/plugins/downloader/menu.js
+++ b/plugins/downloader/menu.js
@@ -32,7 +32,7 @@ module.exports = (win, options) => {
 				const currentURL = metadataURL || win.webContents.getURL();
 				const playlistID = new URL(currentURL).searchParams.get("list");
 				if (!playlistID) {
-					sendError(new Error("No playlist ID found"));
+					sendError(win, new Error("No playlist ID found"));
 					return;
 				}
 
@@ -46,6 +46,7 @@ module.exports = (win, options) => {
 				const playlistFolder = join(folder, playlistTitle);
 				if (existsSync(playlistFolder)) {
 					sendError(
+						win,
 						new Error(`The folder ${playlistFolder} already exists`)
 					);
 					return;

--- a/plugins/downloader/menu.js
+++ b/plugins/downloader/menu.js
@@ -32,7 +32,7 @@ module.exports = (win, options) => {
 				const currentURL = metadataURL || win.webContents.getURL();
 				const playlistID = new URL(currentURL).searchParams.get("list");
 				if (!playlistID) {
-					sendError(win, new Error("No playlist ID found"));
+					sendError(new Error("No playlist ID found"));
 					return;
 				}
 
@@ -46,7 +46,6 @@ module.exports = (win, options) => {
 				const playlistFolder = join(folder, playlistTitle);
 				if (existsSync(playlistFolder)) {
 					sendError(
-						win,
 						new Error(`The folder ${playlistFolder} already exists`)
 					);
 					return;

--- a/plugins/downloader/utils.js
+++ b/plugins/downloader/utils.js
@@ -3,3 +3,33 @@ const electron = require("electron");
 module.exports.getFolder = (customFolder) =>
 	customFolder || (electron.app || electron.remote.app).getPath("downloads");
 module.exports.defaultMenuDownloadLabel = "Download playlist";
+
+module.exports.UrlToJPG = (imgUrl, videoId) => {
+	if (!imgUrl || imgUrl.includes(".jpg")) return imgUrl;
+	if (imgUrl.includes("maxresdefault")) {
+		return "https://img.youtube.com/vi/"+videoId+"/maxresdefault.jpg";
+	}
+	if (imgUrl.includes("hqdefault")) {
+		return "https://img.youtube.com/vi/"+videoId+"/hqdefault.jpg";
+	} //it will almost never get further than hq
+	if (imgUrl.includes("mqdefault")) {
+		return "https://img.youtube.com/vi/"+videoId+"/mqdefault.jpg";
+	}
+	if (imgUrl.includes("sdddefault")) {
+		return "https://img.youtube.com/vi/"+videoId+"/sdddefault.jpg";
+	}
+	return "https://img.youtube.com/vi/"+videoId+"/default.jpg";
+}
+
+module.exports.cropMaxWidth = (image) => {
+	const imageSize = image.getSize();
+	if (imageSize.width === 1280 && imageSize.height === 720) {
+		return image.crop({
+			x: 280,
+			y: 0,
+			width: 720,
+			height: 720
+		});
+	}
+	return image;
+}

--- a/plugins/downloader/utils.js
+++ b/plugins/downloader/utils.js
@@ -4,25 +4,21 @@ module.exports.getFolder = (customFolder) =>
 	customFolder || (electron.app || electron.remote.app).getPath("downloads");
 module.exports.defaultMenuDownloadLabel = "Download playlist";
 
+const orderedQualityList = ["maxresdefault", "hqdefault", "mqdefault", "sdddefault"];
 module.exports.UrlToJPG = (imgUrl, videoId) => {
 	if (!imgUrl || imgUrl.includes(".jpg")) return imgUrl;
-	if (imgUrl.includes("maxresdefault")) {
-		return "https://img.youtube.com/vi/"+videoId+"/maxresdefault.jpg";
+	//it will almost never get further than hqdefault
+	for (const quality of orderedQualityList) {
+		if (imgUrl.includes(quality)) {
+			return `https://img.youtube.com/vi/${videoId}/${quality}.jpg`;
+		}
 	}
-	if (imgUrl.includes("hqdefault")) {
-		return "https://img.youtube.com/vi/"+videoId+"/hqdefault.jpg";
-	} //it will almost never get further than hq
-	if (imgUrl.includes("mqdefault")) {
-		return "https://img.youtube.com/vi/"+videoId+"/mqdefault.jpg";
-	}
-	if (imgUrl.includes("sdddefault")) {
-		return "https://img.youtube.com/vi/"+videoId+"/sdddefault.jpg";
-	}
-	return "https://img.youtube.com/vi/"+videoId+"/default.jpg";
+	return `https://img.youtube.com/vi/${videoId}/default.jpg`;
 }
 
 module.exports.cropMaxWidth = (image) => {
 	const imageSize = image.getSize();
+	// standart youtube artwork width with margins from both sides is 280 + 720 + 280
 	if (imageSize.width === 1280 && imageSize.height === 720) {
 		return image.crop({
 			x: 280,

--- a/plugins/downloader/youtube-dl.js
+++ b/plugins/downloader/youtube-dl.js
@@ -14,7 +14,7 @@ const ytdl = require("ytdl-core");
 
 const { triggerAction, triggerActionSync } = require("../utils");
 const { ACTIONS, CHANNEL } = require("./actions.js");
-const { getFolder } = require("./utils");
+const { getFolder, UrlToJPG } = require("./utils");
 const { cleanupArtistName } = require("../../providers/song-info");
 
 const { createFFmpeg } = FFmpeg;
@@ -37,12 +37,14 @@ const downloadVideoToMP3 = async (
 	sendFeedback("Downloading…");
 
 	if (metadata === null) {
-		const info = await ytdl.getInfo(videoUrl);
-		const thumbnails = info.videoDetails?.author?.thumbnails;
+		const { videoDetails } = await ytdl.getInfo(videoUrl);
+		const thumbnails = videoDetails?.thumbnails;
 		metadata = {
-			artist: info.videoDetails?.media?.artist || cleanupArtistName(info.videoDetails?.author?.name) || "",
-			title: info.videoDetails?.media?.song || info.videoDetails?.title || "",
-			imageSrc: thumbnails ? thumbnails[thumbnails.length - 1].url : ""
+			artist: videoDetails?.media?.artist || cleanupArtistName(videoDetails?.author?.name) || "",
+			title: videoDetails?.media?.song || videoDetails?.title || "",
+			imageSrc: thumbnails ? 
+				UrlToJPG(thumbnails[thumbnails.length - 1].url, videoDetails?.videoId) 
+				: ""
 		}
 	}
 
@@ -65,9 +67,10 @@ const downloadVideoToMP3 = async (
 		.on("data", (chunk) => {
 			chunks.push(chunk);
 		})
-		.on("progress", (chunkLength, downloaded, total) => {
-			const progress = Math.floor((downloaded / total) * 100);
-			sendFeedback("Download: " + progress + "%");
+		.on("progress", (_chunkLength, downloaded, total) => {
+			const ratio = downloaded / total;
+			const progress = Math.floor(ratio * 100);
+			sendFeedback("Download: " + progress + "%", ratio);
 		})
 		.on("info", (info, format) => {
 			videoName = info.videoDetails.title.replace("|", "").toString("ascii");
@@ -112,7 +115,7 @@ const toMP3 = async (
 
 	try {
 		if (!ffmpeg.isLoaded()) {
-			sendFeedback("Loading…");
+			sendFeedback("Loading…", 2); // indefinite progress bar after download
 			await ffmpeg.load();
 		}
 

--- a/plugins/downloader/youtube-dl.js
+++ b/plugins/downloader/youtube-dl.js
@@ -42,7 +42,7 @@ const downloadVideoToMP3 = async (
 		metadata = {
 			artist: videoDetails?.media?.artist || cleanupArtistName(videoDetails?.author?.name) || "",
 			title: videoDetails?.media?.song || videoDetails?.title || "",
-			imageSrc: thumbnails ? 
+			imageSrcYTPL: thumbnails ? 
 				UrlToJPG(thumbnails[thumbnails.length - 1].url, videoDetails?.videoId) 
 				: ""
 		}
@@ -149,7 +149,7 @@ const toMP3 = async (
 		ipcRenderer.send("add-metadata", filePath, fileBuffer, {
 			artist: metadata.artist,
 			title: metadata.title,
-			imageSrc: metadata.imageSrc
+			imageSrcYTPL: metadata.imageSrcYTPL
 		});
 		ipcRenderer.once("add-metadata-done", reinit);
 	} catch (e) {

--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -31,8 +31,7 @@ const getPausedStatus = async (win) => {
 
 const getArtist = async (win) => {
 	return await win.webContents.executeJavaScript(`
-		document.querySelector(".subtitle.ytmusic-player-bar")
-			?.querySelector(".yt-formatted-string")
+		document.querySelector(".subtitle.ytmusic-player-bar .yt-formatted-string")
 			?.textContent
 	`);
 }

--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -53,16 +53,14 @@ const songInfo = {
 
 const handleData = async (responseText, win) => {
 	let data = JSON.parse(responseText);
-	songInfo.title = data.videoDetails?.media?.song || data?.videoDetails?.title;
-	songInfo.artist = data.videoDetails?.media?.artist || await getArtist(win) || cleanupArtistName(data?.videoDetails?.author);
+	songInfo.title = data?.videoDetails?.title;
+	songInfo.artist = await getArtist(win) || cleanupArtistName(data?.videoDetails?.author);
 	songInfo.views = data?.videoDetails?.viewCount;
 	songInfo.imageSrc = data?.videoDetails?.thumbnail?.thumbnails?.pop()?.url;
 	songInfo.songDuration = data?.videoDetails?.lengthSeconds;
 	songInfo.image = await getImage(songInfo.imageSrc);
 	songInfo.uploadDate = data?.microformat?.microformatDataRenderer?.uploadDate;
 	songInfo.url = data?.microformat?.microformatDataRenderer?.urlCanonical;
-
-	console.log("updating song-info");
 
 	win.webContents.send("update-song-info", JSON.stringify(songInfo));
 };

--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -30,15 +30,11 @@ const getPausedStatus = async (win) => {
 };
 
 const getArtist = async (win) => {
-	return await win.webContents.executeJavaScript(
-		`
-		var bar = document.getElementsByClassName('subtitle ytmusic-player-bar')[0];
-		var artistName = (bar.getElementsByClassName('yt-formatted-string')[0]) || (bar.getElementsByClassName('byline ytmusic-player-bar')[0]);
-		if (artistName) {
-			artistName.textContent;
-		}
-		`
-	);
+	return await win.webContents.executeJavaScript(`
+		document.querySelector(".subtitle.ytmusic-player-bar")
+			?.querySelector(".yt-formatted-string")
+			?.textContent
+	`);
 }
 
 // Fill songInfo with empty values
@@ -65,6 +61,8 @@ const handleData = async (responseText, win) => {
 	songInfo.image = await getImage(songInfo.imageSrc);
 	songInfo.uploadDate = data?.microformat?.microformatDataRenderer?.uploadDate;
 	songInfo.url = data?.microformat?.microformatDataRenderer?.urlCanonical;
+
+	console.log("updating song-info");
 
 	win.webContents.send("update-song-info", JSON.stringify(songInfo));
 };


### PR DESCRIPTION
* Use metadata.image from song-info provider only if not sending imgUrl from front (fixes out of sync artwork)
  https://github.com/th-ch/youtube-music/blob/6b88397f820eee0d94cbc4f4bef7f420f1ac2468/plugins/downloader/back.js#L51-L56
* Gets the best artwork possible using `UrlToJPG` + `cropMaxWidth` (in [downloader/utils](https://github.com/th-ch/youtube-music/blob/3831e61d106b5f9cfa61971ba3ca011a70b7bf3b/plugins/downloader/utils.js))
  (`UrlToJPG` is needed because `videoDetails?.thumbnails[-1]` is not always presented in jpg format (webp throw errors) + can be of different sizes. so this function guarantee the highest resolution of artwork)
  (`cropMaxWidth` gets pixel perfect cropping for official music artwork, without it the artwork usually have just big margins filled with solid color)
* Dodge possible thrown errors + more accurate query selector for the "start radio" button in the popup menu:
  https://github.com/th-ch/youtube-music/blob/a8ac2c3af988f299be85010e7fea541096b7e261/plugins/downloader/front.js#L44-L47
* Adds a taskbar progress bar when downloading single songs, this allows seeing download progress without the submenu open (already implemented for playlists)
