### PR TITLE
fix last-fm overwrite config on each start

### DIFF
--- a/plugins/last-fm/back.js
+++ b/plugins/last-fm/back.js
@@ -131,7 +131,7 @@ let scrobbleTimer = undefined;
 const lastfm = async (win, config) => {
 	const registerCallback = getSongInfo(win);
 
-	if (!config.api_root || !config.suffixesToRemove) {
+	if (!config.api_root) {
 		// settings are not present, creating them with the default values
 		config = defaultConfig.plugins['last-fm'];
 		config.enabled = true;


### PR DESCRIPTION
`config.suffixesToRemove` was removed, but this check was left in the code by accident