### PR TITLE
[DRAFT] songInfo from front

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -167,6 +167,14 @@ const mainMenuTemplate = (win) => [
 							config.set("options.autoResetAppCache", item.checked);
 						},
 					},
+					{
+						label: "Override SongInfo",
+						type: "checkbox",
+						checked: config.get("options.overrideSongInfo"),
+						click: (item) => {
+							config.set("options.overrideSongInfo", item.checked);
+						},
+					},
 					{ type: "separator" },
 					{
 						label: "Toggle DevTools",


### PR DESCRIPTION
### EDIT: issue seems to have been fixed for user by deleting all Youtube Music data from .config <br>this PR is probably unneeded. could be closed or kept for reference

It has been reported that some users might experience out of sync songInfo from XHR (no idea why or how)

This PR aims to provide such users with an advanced option "Override SongInfo" that should fix their problem
by getting songInfo from the currently displayed HTML with queryselectors.
should fix #266

> if merged it *might* be better (performance-wise) to drop all `win.webContents.executeJavaScript()`
and instead request one "songInfo" object from song-info-front
