### PR TITLE
fix song-info callback duplication

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const { setApplicationMenu } = require("./menu");
 const { fileExists, injectCSS } = require("./plugins/utils");
 const { isTesting } = require("./utils/testing");
 const { setUpTray } = require("./tray");
+const { setupSongInfo } = require("./providers/song-info");
 
 // Catch errors and log them
 unhandled({
@@ -157,6 +158,7 @@ function createMainWindow() {
 }
 
 app.once("browser-window-created", (event, win) => {
+	setupSongInfo(win);
 	loadPlugins(win);
 
 	win.webContents.on("did-fail-load", (

--- a/plugins/discord/back.js
+++ b/plugins/discord/back.js
@@ -1,6 +1,6 @@
 const Discord = require("discord-rpc");
 
-const getSongInfo = require("../../providers/song-info");
+const registerCallback = require("../../providers/song-info");
 
 const rpc = new Discord.Client({
 	transport: "ipc",
@@ -12,8 +12,6 @@ const clientId = "790655993809338398";
 let clearActivity;
 
 module.exports = (win, {activityTimoutEnabled, activityTimoutTime}) => {
-	const registerCallback = getSongInfo(win);
-
 	// If the page is ready, register the callback
 	win.once("ready-to-show", () => {
 		rpc.once("ready", () => {

--- a/plugins/downloader/back.js
+++ b/plugins/downloader/back.js
@@ -4,7 +4,7 @@ const { join } = require("path");
 const ID3Writer = require("browser-id3-writer");
 const { dialog, ipcMain } = require("electron");
 
-const getSongInfo = require("../../providers/song-info");
+const registerCallback = require("../../providers/song-info");
 const { injectCSS, listenAction } = require("../utils");
 const { cropMaxWidth } = require("./utils");
 const { ACTIONS, CHANNEL } = require("./actions.js");
@@ -25,7 +25,6 @@ let nowPlayingMetadata = {};
 
 function handle(win) {
 	injectCSS(win.webContents, join(__dirname, "style.css"));
-	const registerCallback = getSongInfo(win);
 	registerCallback((info) => {
 		nowPlayingMetadata = info;
 	});

--- a/plugins/downloader/menu.js
+++ b/plugins/downloader/menu.js
@@ -2,13 +2,13 @@ const { existsSync, mkdirSync } = require("fs");
 const { join } = require("path");
 const { URL } = require("url");
 
-const { dialog, ipcMain } = require("electron");
+const { dialog } = require("electron");
 const is = require("electron-is");
 const ytpl = require("ytpl");
 const chokidar = require('chokidar');
 
 const { setOptions } = require("../../config/plugins");
-const getSongInfo = require("../../providers/song-info");
+const registerCallback = require("../../providers/song-info");
 const { sendError } = require("./back");
 const { defaultMenuDownloadLabel, getFolder } = require("./utils");
 
@@ -18,7 +18,6 @@ let callbackIsRegistered = false;
 
 module.exports = (win, options) => {
 	if (!callbackIsRegistered) {
-		const registerCallback = getSongInfo(win);
 		registerCallback((info) => {
 			metadataURL = info.url;
 		});

--- a/plugins/last-fm/back.js
+++ b/plugins/last-fm/back.js
@@ -2,7 +2,7 @@ const fetch = require('node-fetch');
 const md5 = require('md5');
 const { shell } = require('electron');
 const { setOptions } = require('../../config/plugins');
-const getSongInfo = require('../../providers/song-info');
+const registerCallback = require('../../providers/song-info');
 const defaultConfig = require('../../config/defaults');
 
 const createFormData = params => {
@@ -128,9 +128,7 @@ const setNowPlaying = (songInfo, config) => {
 // this will store the timeout that will trigger addScrobble
 let scrobbleTimer = undefined;
 
-const lastfm = async (win, config) => {
-	const registerCallback = getSongInfo(win);
-
+const lastfm = async (_win, config) => {
 	if (!config.api_root) {
 		// settings are not present, creating them with the default values
 		config = defaultConfig.plugins['last-fm'];

--- a/plugins/notifications/back.js
+++ b/plugins/notifications/back.js
@@ -1,6 +1,6 @@
 const { Notification } = require("electron");
 const is = require("electron-is");
-const getSongInfo = require("../../providers/song-info");
+const registerCallback = require("../../providers/song-info");
 const { notificationImage } = require("./utils");
 
 const { setupInteractive, notifyInteractive } = require("./interactive")
@@ -29,7 +29,6 @@ module.exports = (win, options) => {
 	if (isInteractive) {
 		setupInteractive(win, options.unpauseNotification);
 	}
-	const registerCallback = getSongInfo(win);
 	let oldNotification;
 	let oldURL = "";
 	win.once("ready-to-show", () => {

--- a/plugins/notifications/back.js
+++ b/plugins/notifications/back.js
@@ -25,11 +25,13 @@ const notify = (info, options) => {
 
 const setup = (options) => {
 	let oldNotification;
+	let currentUrl;
 
 	registerCallback(songInfo => {
-		if (!songInfo.isPaused || options.unpauseNotification) {
+		if (!songInfo.isPaused && (songInfo.url !== currentUrl || options.unpauseNotification)) {
 			// Close the old notification
 			oldNotification?.close();
+			currentUrl = songInfo.url;
 			// This fixes a weird bug that would cause the notification to be updated instead of showing
 			setTimeout(() => { oldNotification = notify(songInfo, options) }, 10);
 		}

--- a/plugins/notifications/back.js
+++ b/plugins/notifications/back.js
@@ -3,7 +3,7 @@ const is = require("electron-is");
 const registerCallback = require("../../providers/song-info");
 const { notificationImage } = require("./utils");
 
-const { setupInteractive, notifyInteractive } = require("./interactive")
+const setupInteractive = require("./interactive")
 
 const notify = (info, options) => {
 
@@ -23,37 +23,22 @@ const notify = (info, options) => {
 	return currentNotification;
 };
 
-module.exports = (win, options) => {
-	const isInteractive = is.windows() && options.interactive;
-	//setup interactive notifications for windows
-	if (isInteractive) {
-		setupInteractive(win, options.unpauseNotification);
-	}
+const setup = (options) => {
 	let oldNotification;
-	let oldURL = "";
-	win.once("ready-to-show", () => {
-		// Register the callback for new song information
-		registerCallback(songInfo => {
-			// on pause - reset url? and skip notification
-			if (songInfo.isPaused) {
-				//reset oldURL if unpause notification option is on
-				if (options.unpauseNotification) {
-					oldURL = "";
-				}
-				return;
-			}
-			// If url isn't the same as last one - send notification
-			if (songInfo.url !== oldURL) {
-				oldURL = songInfo.url;
-				if (isInteractive) {
-					notifyInteractive(songInfo);
-				} else {
-					// Close the old notification
-					oldNotification?.close();
-					// This fixes a weird bug that would cause the notification to be updated instead of showing
-					setTimeout(() => { oldNotification = notify(songInfo, options) }, 10);
-				}
-			}
-		});
+
+	registerCallback(songInfo => {
+		if (!songInfo.isPaused || options.unpauseNotification) {
+			// Close the old notification
+			oldNotification?.close();
+			// This fixes a weird bug that would cause the notification to be updated instead of showing
+			setTimeout(() => { oldNotification = notify(songInfo, options) }, 10);
+		}
 	});
+}
+
+module.exports = (win, options) => {
+	// Register the callback for new song information
+	is.windows() && options.interactive ?
+		setupInteractive(win, options.unpauseNotification) :
+		setup(options);
 };

--- a/plugins/notifications/interactive.js
+++ b/plugins/notifications/interactive.js
@@ -1,17 +1,24 @@
 const { notificationImage, icons } = require("./utils");
 const getSongControls = require('../../providers/song-controls');
+const registerCallback = require("../../providers/song-info");
 const notifier = require("node-notifier");
 
 //store song controls reference on launch
 let controls;
 let notificationOnPause;
 
-//Save controls and onPause option
-module.exports.setupInteractive = (win, unpauseNotification) => {
+module.exports = (win, unpauseNotification) => {
+    //Save controls and onPause option
     const { playPause, next, previous } = getSongControls(win);
     controls = { playPause, next, previous };
-
     notificationOnPause = unpauseNotification;
+
+    // Register songInfoCallback
+    registerCallback(songInfo => {
+		if (!songInfo.isPaused || notificationOnPause) {
+            sendToaster(songInfo);
+		}
+	});
 
     win.webContents.once("closed", () => {
         deleteNotification()
@@ -33,7 +40,7 @@ function deleteNotification() {
 }
 
 //New notification
-module.exports.notifyInteractive = function sendToaster(songInfo) {
+function sendToaster(songInfo) {
     deleteNotification();
     //download image and get path
     let imgSrc = notificationImage(songInfo, true);

--- a/plugins/notifications/interactive.js
+++ b/plugins/notifications/interactive.js
@@ -5,17 +5,20 @@ const notifier = require("node-notifier");
 
 //store song controls reference on launch
 let controls;
-let notificationOnPause;
+let notificationOnUnpause;
 
 module.exports = (win, unpauseNotification) => {
     //Save controls and onPause option
     const { playPause, next, previous } = getSongControls(win);
     controls = { playPause, next, previous };
-    notificationOnPause = unpauseNotification;
+    notificationOnUnpause = unpauseNotification;
+
+    let currentUrl;
 
     // Register songInfoCallback
     registerCallback(songInfo => {
-		if (!songInfo.isPaused || notificationOnPause) {
+		if (!songInfo.isPaused && (songInfo.url !== currentUrl || notificationOnUnpause)) {
+            currentUrl = songInfo.url;
             sendToaster(songInfo);
 		}
 	});
@@ -78,7 +81,7 @@ function sendToaster(songInfo) {
                     // dont delete notification on play/pause
                     toDelete = undefined;
                     //manually send notification if not sending automatically
-                    if (!notificationOnPause) {
+                    if (!notificationOnUnpause) {
                         songInfo.isPaused = false;
                         sendToaster(songInfo);
                     }

--- a/plugins/taskbar-mediacontrol/back.js
+++ b/plugins/taskbar-mediacontrol/back.js
@@ -1,12 +1,11 @@
 const getSongControls = require('../../providers/song-controls');
-const getSongInfo = require('../../providers/song-info');
+const registerCallback = require('../../providers/song-info');
 const path = require('path');
 
 let controls;
 let currentSongInfo;
 
 module.exports = win => {
-	const registerCallback = getSongInfo(win);
 	const { playPause, next, previous } = getSongControls(win);
 	controls = { playPause, next, previous };
 

--- a/plugins/touchbar/back.js
+++ b/plugins/touchbar/back.js
@@ -7,7 +7,7 @@ const {
 	TouchBarScrubber,
 } = TouchBar;
 
-const getSongInfo = require("../../providers/song-info");
+const registerCallback = require("../../providers/song-info");
 const getSongControls = require("../../providers/song-controls");
 
 // Songtitle label
@@ -59,7 +59,6 @@ const touchBar = new TouchBar({
 });
 
 module.exports = (win) => {
-	const registerCallback = getSongInfo(win);
 	const { playPause, next, previous, like, dislike } = getSongControls(win);
 
 	// If the page is ready, register the callback

--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -51,7 +51,6 @@ const songInfo = {
 };
 
 const handleData = async (responseText, win) => {
-	console.log("handling song-info")
 	let data = JSON.parse(responseText);
 	songInfo.title = data?.videoDetails?.title;
 	songInfo.artist = await getArtist(win) || cleanupArtistName(data?.videoDetails?.author);

--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -51,6 +51,7 @@ const songInfo = {
 };
 
 const handleData = async (responseText, win) => {
+	console.log("handling song-info")
 	let data = JSON.parse(responseText);
 	songInfo.title = data?.videoDetails?.title;
 	songInfo.artist = await getArtist(win) || cleanupArtistName(data?.videoDetails?.author);
@@ -64,15 +65,15 @@ const handleData = async (responseText, win) => {
 	win.webContents.send("update-song-info", JSON.stringify(songInfo));
 };
 
+// This variable will be filled with the callbacks once they register
+const callbacks = [];
+
+// This function will allow plugins to register callback that will be triggered when data changes
+const registerCallback = (callback) => {
+	callbacks.push(callback);
+};
+
 const registerProvider = (win) => {
-	// This variable will be filled with the callbacks once they register
-	const callbacks = [];
-
-	// This function will allow plugins to register callback that will be triggered when data changes
-	const registerCallback = (callback) => {
-		callbacks.push(callback);
-	};
-
 	win.on("page-title-updated", async () => {
 		// Get and set the new data
 		songInfo.isPaused = await getPausedStatus(win);
@@ -93,8 +94,6 @@ const registerProvider = (win) => {
 			c(songInfo);
 		});
 	});
-
-	return registerCallback;
 };
 
 const suffixesToRemove = [' - Topic', 'VEVO'];
@@ -110,7 +109,8 @@ function cleanupArtistName(artist) {
 	return artist;
 }
 
-module.exports = registerProvider;
+module.exports = registerCallback;
+module.exports.setupSongInfo = registerProvider;
 module.exports.getImage = getImage;
 module.exports.cleanupArtistName = cleanupArtistName;
 


### PR DESCRIPTION
## Old behavior
Every plugin had to setup SongInfo separately

Which causes duplication of listener registration `win.on("page-title-updated"...` and `ipcMain.on("song-info-request"...`

Which causes song-info callbacks to be called multiple times 
(because ipcMain callbacks were registered X times and sent X events for each "song-info-request")

## New behavior

songInfo is setup **once** from index.js before plugin load.
Each plugin can register a song-info callback by just requiring it. (without the need to set it up)
> achieved by separating `registerProvider()` and `registerCallback()` in song-info.js

registerCallback example:
```javascript
const registerCallback = require("../../providers/song-info");
registerCallback(songInfo => {
	console.log(songInfo.title);
})
```
> This fix also warranted a small refactor of notifications plugin (which was the most heavily affected by this bug)