### PR TITLE
fix notification showing appID instead of app name on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -255,6 +255,10 @@ app.on("ready", () => {
 		}, 20000);
 	}
 
+	if (is.windows()) {
+		app.setAppUserModelId("com.github.th-ch.youtube-music");
+	}
+
 	mainWindow = createMainWindow();
 	setApplicationMenu(mainWindow);
 	if (config.get("options.restartOnConfigChanges")) {

--- a/index.js
+++ b/index.js
@@ -257,12 +257,13 @@ app.on("ready", () => {
 
 	// Register appID on windows
 	if (is.windows()) {
-		const appLocation = process.execPath;
 		const appID = "com.github.th-ch.youtube-music";
 		app.setAppUserModelId(appID);
+		const appLocation = process.execPath;
+		const appData = app.getPath("appData");
 		// check shortcut validity if not in dev mode / running portable app
-		if (!is.dev() && !appLocation.startsWith(path.join(app.getPath("appData"), "..", "Local", "Temp"))) {
-			const shortcutPath = path.join(app.getPath("appData"), "Microsoft", "Windows", "Start Menu", "Programs", "YouTube Music.lnk");
+		if (!is.dev() && !appLocation.startsWith(path.join(appData, "..", "Local", "Temp"))) {
+			const shortcutPath = path.join(appData, "Microsoft", "Windows", "Start Menu", "Programs", "YouTube Music.lnk");
 			try { // check if shortcut is registered and valid
 				const shortcutDetails = electron.shell.readShortcutLink(shortcutPath); // throw error if doesn't exist yet
 				if (shortcutDetails.target !== appLocation || shortcutDetails.appUserModelId !== appID) {

--- a/index.js
+++ b/index.js
@@ -263,12 +263,12 @@ app.on("ready", () => {
 		try { // check if shortcut is registered and valid
 			const shortcutDetails = electron.shell.readShortcutLink(shortcutPath); // throw error if doesn't exist yet
 			if (shortcutDetails.target !== appLocation || shortcutDetails.appUserModelId !== appID) {
-				throw undefined;
+				throw "needUpdate";
 			}
-		} catch { // if not valid -> Register shortcut
+		} catch (error) { // if not valid -> Register shortcut
 			electron.shell.writeShortcutLink(
 				shortcutPath,
-				"create",
+				error === "needUpdate" ? "update" : "create",
 				{
 					target: appLocation,
 					cwd: appLocation.slice(0, appLocation.lastIndexOf(path.sep)),

--- a/index.js
+++ b/index.js
@@ -255,31 +255,32 @@ app.on("ready", () => {
 		}, 20000);
 	}
 
-	const appLocation = process.execPath;
-	
-	// Register shortcut & appID on windows
-	if (is.windows() && !is.dev() && !appLocation.startsWith(path.join(app.getPath("appData"), "..", "Local", "Temp"))) {
+	// Register appID on windows
+	if (is.windows()) {
+		const appLocation = process.execPath;
 		const appID = "com.github.th-ch.youtube-music";
-		const shortcutPath = path.join(app.getPath("appData"), "Microsoft", "Windows", "Start Menu", "Programs", "YouTube Music.lnk");
-		try { // check if shortcut is registered and valid
-			const shortcutDetails = electron.shell.readShortcutLink(shortcutPath); // throw error if doesn't exist yet
-			if (shortcutDetails.target !== appLocation || shortcutDetails.appUserModelId !== appID) {
-				throw "needUpdate";
-			}
-		} catch (error) { // if not valid -> Register shortcut
-			electron.shell.writeShortcutLink(
-				shortcutPath,
-				error === "needUpdate" ? "update" : "create",
-				{
-					target: appLocation,
-					cwd: appLocation.slice(0, appLocation.lastIndexOf(path.sep)),
-					description: "YouTube Music Desktop App - including custom plugins",
-					appUserModelId: appID
-				}
-			);
-		}
-		// set appID
 		app.setAppUserModelId(appID);
+		// check shortcut validity if not in dev mode / running portable app
+		if (!is.dev() && !appLocation.startsWith(path.join(app.getPath("appData"), "..", "Local", "Temp"))) {
+			const shortcutPath = path.join(app.getPath("appData"), "Microsoft", "Windows", "Start Menu", "Programs", "YouTube Music.lnk");
+			try { // check if shortcut is registered and valid
+				const shortcutDetails = electron.shell.readShortcutLink(shortcutPath); // throw error if doesn't exist yet
+				if (shortcutDetails.target !== appLocation || shortcutDetails.appUserModelId !== appID) {
+					throw "needUpdate";
+				}
+			} catch (error) { // if not valid -> Register shortcut
+				electron.shell.writeShortcutLink(
+					shortcutPath,
+					error === "needUpdate" ? "update" : "create",
+					{
+						target: appLocation,
+						cwd: appLocation.slice(0, appLocation.lastIndexOf(path.sep)),
+						description: "YouTube Music Desktop App - including custom plugins",
+						appUserModelId: appID
+					}
+				);
+			}
+		}
 	}
 
 	mainWindow = createMainWindow();

--- a/index.js
+++ b/index.js
@@ -255,11 +255,12 @@ app.on("ready", () => {
 		}, 20000);
 	}
 
+	const appLocation = process.execPath;
+	
 	// Register shortcut & appID on windows
-	if (!is.dev() && is.windows()) {
+	if (is.windows() && !is.dev() && !appLocation.startsWith(path.join(app.getPath("appData"), "..", "Local", "Temp"))) {
 		const appID = "com.github.th-ch.youtube-music";
 		const shortcutPath = path.join(app.getPath("appData"), "Microsoft", "Windows", "Start Menu", "Programs", "YouTube Music.lnk");
-		const appLocation = process.execPath;
 		try { // check if shortcut is registered and valid
 			const shortcutDetails = electron.shell.readShortcutLink(shortcutPath); // throw error if doesn't exist yet
 			if (shortcutDetails.target !== appLocation || shortcutDetails.appUserModelId !== appID) {

--- a/index.js
+++ b/index.js
@@ -255,17 +255,29 @@ app.on("ready", () => {
 		}, 20000);
 	}
 
+	// Register shortcut & appID on windows
 	if (!is.dev() && is.windows()) {
 		const appID = "com.github.th-ch.youtube-music";
-		electron.shell.writeShortcutLink(
-			path.join(app.getPath("appData"), 'Microsoft', 'Windows', 'Start Menu', 'Programs', 'YouTube Music.lnk'),
-			'update',
-			{
-				target: process.execPath,
-				description: "YouTube Music Desktop App - including custom plugins",
-				appUserModelId: appID
+		const shortcutPath = path.join(app.getPath("appData"), "Microsoft", "Windows", "Start Menu", "Programs", "YouTube Music.lnk");
+		const appLocation = process.execPath;
+		try { // check if shortcut is registered and valid
+			const shortcutDetails = electron.shell.readShortcutLink(shortcutPath); // throw error if doesn't exist yet
+			if (shortcutDetails.target !== appLocation || shortcutDetails.appUserModelId !== appID) {
+				throw undefined;
 			}
-		);
+		} catch { // if not valid -> Register shortcut
+			electron.shell.writeShortcutLink(
+				shortcutPath,
+				"create",
+				{
+					target: appLocation,
+					cwd: appLocation.slice(0, appLocation.lastIndexOf(path.sep)),
+					description: "YouTube Music Desktop App - including custom plugins",
+					appUserModelId: appID
+				}
+			);
+		}
+		// set appID
 		app.setAppUserModelId(appID);
 	}
 

--- a/index.js
+++ b/index.js
@@ -255,8 +255,18 @@ app.on("ready", () => {
 		}, 20000);
 	}
 
-	if (is.windows()) {
-		app.setAppUserModelId("com.github.th-ch.youtube-music");
+	if (!is.dev() && is.windows()) {
+		const appID = "com.github.th-ch.youtube-music";
+		electron.shell.writeShortcutLink(
+			path.join(app.getPath("appData"), 'Microsoft', 'Windows', 'Start Menu', 'Programs', 'YouTube Music.lnk'),
+			'update',
+			{
+				target: process.execPath,
+				description: "YouTube Music Desktop App - including custom plugins",
+				appUserModelId: appID
+			}
+		);
+		app.setAppUserModelId(appID);
 	}
 
 	mainWindow = createMainWindow();


### PR DESCRIPTION
## Before:
![appID Unset](https://user-images.githubusercontent.com/78568641/117701576-1515db80-b1d0-11eb-9a5a-fa316ca370d9.png)
## After:
![appID Fixed](https://user-images.githubusercontent.com/78568641/117701595-1a732600-b1d0-11eb-9308-da2336c7fc76.png)

This sets the appID +
if not in dev mode OR running from portable app -> check the windows startMenu shortcut and fix it if necessary, 
(Since this fix works only if shortcut is correctly registered in startMenu)

> This only fix **normal** notifications. fix for interactive notifications is [coming soon](https://github.com/mikaelbr/node-notifier/pull/375)