### PR TITLE
add volume hud to precise-volume plugin

### DIFF
--- a/plugins/precise-volume/back.js
+++ b/plugins/precise-volume/back.js
@@ -1,5 +1,3 @@
-const { isEnabled } = require("../../config/plugins");
-
 /*
 This is used to determine if plugin is actually active
 (not if its only enabled in options)
@@ -9,12 +7,8 @@ let enabled = false;
 module.exports = (win) => {
 	enabled = true;
 
-	// youtube-music register some of the target listeners after DOMContentLoaded
-	// did-finish-load is called after all elements finished loading, including said listeners
-	// Thats the reason the timing is controlled from main
 	win.webContents.once("did-finish-load", () => {
-		win.webContents.send("restoreAddEventListener");
-		win.webContents.send("setupVideoPlayerVolumeMousewheel", !isEnabled("hide-video-player"));
+		win.webContents.send("did-finish-load");
 	});
 };
 

--- a/plugins/precise-volume/preload.js
+++ b/plugins/precise-volume/preload.js
@@ -25,7 +25,7 @@ function overrideAddEventListener() {
 module.exports = () => {
     overrideAddEventListener();
     // Restore original function after did-finish-load to avoid keeping Element.prototype altered
-    ipcRenderer.once("restoreAddEventListener", () => { // Called from main to make sure page is completly loaded
+    ipcRenderer.once("did-finish-load", () => { // Called from main to make sure page is completly loaded
         Element.prototype.addEventListener = Element.prototype._addEventListener;
         Element.prototype._addEventListener = undefined;
         ignored = undefined;


### PR DESCRIPTION
This adds a hud for the volume
(display volume percentage on change, fade out after 2 seconds)

I know there is `utils.elementFromFile` etc, buts since the element is so small, its much quicker and shorter (code wise) to just directly use `Element.insertAdjacentHTML`
