### PR TITLE
Audio compressor plugin

### DIFF
--- a/plugins/audio-compressor/front.js
+++ b/plugins/audio-compressor/front.js
@@ -1,0 +1,32 @@
+const {
+	watchDOMElement
+} = require("../../providers/dom-elements");
+
+let videoElement;
+
+const applyCompressor = () => {
+	var audioContext = new AudioContext();
+	
+	var compressor = audioContext.createDynamicsCompressor();
+	compressor.threshold.value = -50;
+	compressor.ratio.value = 12;
+	compressor.knee.value = 40;
+	compressor.attack.value = 0;
+	compressor.release.value = 0.25;
+
+	var source = audioContext.createMediaElementSource(videoElement);
+
+	source.connect(compressor);
+	compressor.connect(audioContext.destination);
+};
+
+module.exports = () => {
+	watchDOMElement(
+		"video",
+		(document) => document.querySelector("video"),
+		(element) => {
+			videoElement = element;
+			applyCompressor();
+		}
+	);
+};


### PR DESCRIPTION
This plugin adds [DynamicsCompressorNode](https://developer.mozilla.org/en-US/docs/Web/API/DynamicsCompressorNode) onto the audio that is being played which should help with the case where there are two videos with different volume in the video's audio itself.

Example:
[vid1 (which is loud) compared to](https://music.youtube.com/watch?v=vz7EQTtzPo8&t=52)
[vid2](https://music.youtube.com/watch?v=n-4SVb8ZoIU&t=70)
without the plugin:
![audacity screenshot of both without the plugin](https://user-images.githubusercontent.com/26690825/118479288-20f22800-b711-11eb-8f95-c0b5af410162.png)
with the plugin:
![audacity screenshot of both with the plugin](https://user-images.githubusercontent.com/26690825/118481806-2d2bb480-b714-11eb-858a-9d0b5b83a785.png)
