### PR TITLE
fix hidden webp thumbnail throwing MIME type error in downloader

### DIFF
--- a/plugins/downloader/back.js
+++ b/plugins/downloader/back.js
@@ -55,7 +55,9 @@ function handle(win) {
 			{ ...nowPlayingMetadata, ...currentMetadata };
 
 		try {
-			const coverBuffer = songMetadata.image ? songMetadata.image.toPNG() : null;
+			const coverBuffer = songMetadata.image && !songMetadata.image.isEmpty() ?
+				songMetadata.image.toPNG() : null;
+
 			const writer = new ID3Writer(songBuffer);
 
 			// Create the metadata tags

--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -9,18 +9,21 @@ const progressSelector = "#progress-bar";
 // Grab the progress using the selector
 const getProgress = async (win) => {
 	// Get current value of the progressbar element
-	const elapsedSeconds = await win.webContents.executeJavaScript(
+	return win.webContents.executeJavaScript(
 		'document.querySelector("' + progressSelector + '").value'
 	);
-
-	return elapsedSeconds;
 };
 
 // Grab the native image using the src
 const getImage = async (src) => {
 	const result = await fetch(src);
 	const buffer = await result.buffer();
-	return nativeImage.createFromBuffer(buffer);
+	const output = nativeImage.createFromBuffer(buffer);
+	if (output.isEmpty() && !src.endsWith(".jpg") && src.includes(".jpg")) { // fix hidden webp files (https://github.com/th-ch/youtube-music/issues/315)
+		return getImage(src.slice(0, src.lastIndexOf(".jpg")+4));
+	} else {
+		return output;
+	}
 };
 
 // To find the paused status, we check if the title contains `-`
@@ -30,7 +33,7 @@ const getPausedStatus = async (win) => {
 };
 
 const getArtist = async (win) => {
-	return await win.webContents.executeJavaScript(`
+	return win.webContents.executeJavaScript(`
 		document.querySelector(".subtitle.ytmusic-player-bar .yt-formatted-string")
 			?.textContent
 	`);
@@ -112,4 +115,3 @@ module.exports = registerCallback;
 module.exports.setupSongInfo = registerProvider;
 module.exports.getImage = getImage;
 module.exports.cleanupArtistName = cleanupArtistName;
-


### PR DESCRIPTION
Fix #315

## The Problem

youtube sometimes hide the real picture filetype, for example in this link:

https://i.ytimg.com/vi/tmntIJSf0Dw/hqdefault.jpg?sqp=-oaymwEcCNACELwBSFXyq4qpAw4IARUAAIhCGAFwAcABBg==&rs=AOn4CLC5b9hkS4_861N7ooUq4fUGX7RLCw

the `.jpg` is a lie, this file is a webp - and Electron's `nativeImage` doesn't support this type.
(when trying to save the picture in a browser, it will auto suggest name `hqdefault.jpg.webp`..)

this results in an empty native image - and setting `APIC` frame to an empty buffer:
https://github.com/th-ch/youtube-music/blob/3485d26b111c708f0c0aac6a7dec34b49435fc5d/plugins/downloader/back.js#L66-L68
results in a thrown error: `Unknown picture MIME type`

## The Fix

fixed by removing everything that comes after the ".jpg" (only if needed - the nativeImage is empty)
in our example the result is: 
https://i.ytimg.com/vi/tmntIJSf0Dw/hqdefault.jpg
which is a valid jpg file

> Also check before creating coverBuffer that nativeImage isn't empty to avoid potential error throwing