### PR TITLE
Fix discord clearActivity, menu

### DIFF
--- a/plugins/discord/menu.js
+++ b/plugins/discord/menu.js
@@ -1,0 +1,21 @@
+const { setOptions } = require("../../config/plugins");
+const { edit } = require("../../config");
+
+module.exports = (win, options) => [
+	{
+		label: "Clear activity after timeout",
+		type: "checkbox",
+		checked: options.activityTimoutEnabled,
+		click: (item) => {
+			options.activityTimoutEnabled = item.checked;
+			setOptions('discord', options);
+		},
+	},
+	{
+		label: "Set timeout time in config",
+		click: () => {
+			// open config.json
+			edit();
+		},
+	},
+];


### PR DESCRIPTION
The callback sends multiple events, in particular two pause when going to the next song, so the timeout wasn't properly cleared. I have documented this.

Added menu buttons for the two options. Currently for the timeout time I simply open the config, to allow the user to properly input a number here a library is needed.