### PR TITLE
Bump node to v14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v1
         with:
-          node-version: "12.x"
+          node-version: "14.x"
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"release:win": "yarn run clean && electron-builder --win -p always"
 	},
 	"engines": {
-		"node": ">=12.20",
+		"node": ">=14.0.0",
 		"npm": "Please use yarn and not npm"
 	},
 	"dependencies": {


### PR DESCRIPTION
This PR bumps the node version used to 14.x.x - v12 makes the [build fail](https://github.com/th-ch/youtube-music/runs/3395356117).