### PR TITLE
fix: mpris instance not registering itself and media controls

### DIFF
--- a/plugins/shortcuts/back.js
+++ b/plugins/shortcuts/back.js
@@ -36,6 +36,9 @@ function registerShortcuts(win, options) {
 				'xesam:title': songInfo.title,
 				'xesam:artist': songInfo.artist
 			};
+			if (!songInfo.isPaused) {
+				player.playbackStatus = "Playing"
+			}
 		}
 	}
 	)


### PR DESCRIPTION
Sorry, I missed that MPRIS was not getting registered for youtube-music, and I was not wrong with the statement 
>  MPRIS is working in linux

because when youtube music is running there is also an chromium instance which register itself for MPRIS, and the playerctl command I used to test that was play, pause, next and prev but I did not listed my all player instance that time to see if it is really youtube-music mpris is registered or not. All the command worked that time because chromium instance was listening for those command.

So I fixed that and also tested again "**PROPERLY**" with playerctl -p youtube-music commands, and also with mediaplayer perl script which I am using in my i3blocks. 

Again **I am sorry I did not tested mpris support PR properly.**