### PR TITLE
set resume on start url to songInfo.url

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,13 +197,6 @@ app.once("browser-window-created", (event, win) => {
 		event.preventDefault();
 	});
 
-	win.webContents.on("did-navigate-in-page", () => {
-		const url = win.webContents.getURL();
-		if (url.startsWith("https://music.youtube.com")) {
-			config.set("url", url);
-		}
-	});
-
 	win.webContents.on("will-navigate", (_, url) => {
 		if (url.startsWith("https://accounts.google.com")) {
 			// Force user-agent "Firefox Windows" for Google OAuth to work

--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -2,6 +2,8 @@ const { ipcMain, nativeImage } = require("electron");
 
 const fetch = require("node-fetch");
 
+const config = require("../config");
+
 // Grab the progress using the selector
 const getProgress = async (win) => {
 	// Get current value of the progressbar element
@@ -55,6 +57,9 @@ const handleData = async (responseText, win) => {
 	songInfo.image = await getImage(songInfo.imageSrc);
 	songInfo.uploadDate = data?.microformat?.microformatDataRenderer?.uploadDate;
 	songInfo.url = data?.microformat?.microformatDataRenderer?.urlCanonical?.split("&")[0];
+
+	// used for options.resumeOnStart
+	config.set("url", data?.microformat?.microformatDataRenderer?.urlCanonical);
 
 	win.webContents.send("update-song-info", JSON.stringify(songInfo));
 };


### PR DESCRIPTION
Fix #444 by setting `config.url` to the current playing song url from songInfo
(including playlist info unlike `songInfo.url`)