### PR TITLE
Missed audio-compressor plugin in defaults.js

### DIFF
--- a/config/defaults.js
+++ b/config/defaults.js
@@ -28,6 +28,9 @@ const defaultConfig = {
 			additionalBlockLists: [], // Additional list of filters, e.g "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters.txt"
 		},
 		// Disabled plugins
+		"audio-compressor": {
+			"enabled": false
+		},
 		shortcuts: {
 			enabled: false,
 			overrideMediaKeys: false,


### PR DESCRIPTION
Add audio-compressor to the plugin list.
It works great and it is only one reason why I download this app. Thanks!!!