### PR TITLE
use apiLoaded event in audio-compressor plugin

### DIFF
--- a/plugins/audio-compressor/front.js
+++ b/plugins/audio-compressor/front.js
@@ -1,14 +1,6 @@
 const applyCompressor = () => {
-	const videoElement = document.querySelector("video");
-
-	// If video element is not loaded yet try again
-	if(videoElement === null) {
-		setTimeout(applyCompressor, 500);
-		return;
-	}
-
 	const audioContext = new AudioContext();
-	
+
 	let compressor = audioContext.createDynamicsCompressor();
 	compressor.threshold.value = -50;
 	compressor.ratio.value = 12;
@@ -16,10 +8,12 @@ const applyCompressor = () => {
 	compressor.attack.value = 0;
 	compressor.release.value = 0.25;
 
-	const source = audioContext.createMediaElementSource(videoElement);
+	const source = audioContext.createMediaElementSource(document.querySelector("video"));
 
 	source.connect(compressor);
 	compressor.connect(audioContext.destination);
 };
 
-module.exports = applyCompressor;
+module.exports = () => document.addEventListener('apiLoaded', () => {
+	applyCompressor();
+})


### PR DESCRIPTION
simple optimization
(video element is always loaded when [`apiLoaded`](https://github.com/th-ch/youtube-music/blob/a47c906ab2ac47bd0a5589099b4e32bf1d3c4ae6/preload.js#L59-L78) is fired)