### PR TITLE
Fix sponsorblock skipping when not needed

### DIFF
--- a/plugins/in-app-menu/front.js
+++ b/plugins/in-app-menu/front.js
@@ -17,16 +17,15 @@ module.exports = () => {
 
 	// Increases the right margin of Navbar background when the scrollbar is visible to avoid blocking it (z-index doesn't affect it)
 	document.addEventListener('apiLoaded', () => {
-		setNavbarMargin()
-		const playPageObserver = new MutationObserver(() => {
-			setNavbarMargin();
-		});
+		setNavbarMargin();
+		const playPageObserver = new MutationObserver(setNavbarMargin);
 		playPageObserver.observe($('ytmusic-app-layout'), { attributeFilter: ['player-page-open_', 'playerPageOpen_'] })
-	})
+	}, { once: true, passive: true })
 };
 
 function setNavbarMargin() {
-	$('ytmusic-app-layout').playerPageOpen_ ?
-		$('#nav-bar-background').style.right = '0px' :
-		$('#nav-bar-background').style.right = '12px';
+	$('#nav-bar-background').style.right =
+		$('ytmusic-app-layout').playerPageOpen_ ?
+			'0px' :
+			'12px';
 }

--- a/plugins/sponsorblock/front.js
+++ b/plugins/sponsorblock/front.js
@@ -10,7 +10,9 @@ module.exports = () => {
 	});
 
 	document.addEventListener('apiLoaded', () => {
-		document.querySelector('video').addEventListener('timeupdate', e => {
+		const video = document.querySelector('video');
+
+		video.addEventListener('timeupdate', e => {
 			currentSegments.forEach((segment) => {
 				if (
 					e.target.currentTime >= segment[0] &&
@@ -23,5 +25,7 @@ module.exports = () => {
 				}
 			});
 		})
+		// Reset segments on song end
+		video.addEventListener('emptied', () => currentSegments = []);
 	}, { once: true, passive: true })
 };

--- a/providers/song-info-front.js
+++ b/providers/song-info-front.js
@@ -11,7 +11,7 @@ ipcRenderer.on("update-song-info", async (_, extractedSongInfo) => {
 
 module.exports = () => {
 	document.addEventListener('apiLoaded', e => {
-		document.querySelector('video').addEventListener('loadeddata', () => {
+		document.querySelector('video').addEventListener('loadedmetadata', () => {
 			const data = e.detail.getPlayerResponse();
 			ipcRenderer.send("song-info-request", JSON.stringify(data));
 		});


### PR DESCRIPTION
* Fix sponsorblock skipping when not needed by resetting the segments before next song load (using the "emptied" event)

  The bug originally occurred because "timeupdate" was called while the segments were still from the old song because there is a slight delay getting them from ipc->songInfo->**fetch**->json->sort->ipc etc..

* use `loadedmetadata` instead of `loadeddata` in song-info-front since the data is already available (its only a few milliseconds faster but whatever helps)

* small lint for in-app-menu