### PR TITLE
Various small fixes (discord, video-toggle, precise-volume, playback-speed, shortcuts, lyrics)

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"@ffmpeg/ffmpeg": "^0.10.0",
 		"async-mutex": "^0.3.2",
 		"browser-id3-writer": "^4.4.0",
-		"custom-electron-prompt": "^1.3.0",
+		"custom-electron-prompt": "^1.3.1",
 		"chokidar": "^3.5.2",
 		"custom-electron-titlebar": "^3.2.7",
 		"discord-rpc": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"@ffmpeg/ffmpeg": "^0.10.0",
 		"async-mutex": "^0.3.2",
 		"browser-id3-writer": "^4.4.0",
-		"custom-electron-prompt": "^1.2.0",
+		"custom-electron-prompt": "^1.3.0",
 		"chokidar": "^3.5.2",
 		"custom-electron-titlebar": "^3.2.7",
 		"discord-rpc": "^3.2.0",

--- a/plugins/discord/back.js
+++ b/plugins/discord/back.js
@@ -1,6 +1,6 @@
 const Discord = require("discord-rpc");
 const { dev } = require("electron-is");
-const { dialog } = require("electron");
+const { dialog, app } = require("electron");
 
 const registerCallback = require("../../providers/song-info");
 
@@ -70,7 +70,7 @@ let clearActivity;
  */
 let updateActivity;
 
-module.exports = (win, {activityTimoutEnabled, activityTimoutTime, listenAlong}) => {
+module.exports = (win, { activityTimoutEnabled, activityTimoutTime, listenAlong }) => {
 	window = win;
 	// We get multiple events
 	// Next song: PAUSE(n), PAUSE(n+1), PLAY(n+1)
@@ -136,7 +136,7 @@ module.exports = (win, {activityTimoutEnabled, activityTimoutTime, listenAlong})
 		registerCallback(updateActivity);
 		connect();
 	});
-	win.on("close", () => module.exports.clear());
+	app.on('window-all-closed', module.exports.clear)
 };
 
 module.exports.clear = () => {

--- a/plugins/lyrics-genius/style.css
+++ b/plugins/lyrics-genius/style.css
@@ -5,3 +5,8 @@
 	pointer-events: none;
 	text-decoration: none;
 }
+
+#contents.genius-lyrics {
+    font-size: initial;
+    opacity: 0.9;
+}

--- a/plugins/playback-speed/front.js
+++ b/plugins/playback-speed/front.js
@@ -5,14 +5,12 @@ function $(selector) { return document.querySelector(selector); }
 
 const slider = ElementFromFile(templatePath(__dirname, "slider.html"));
 
-const roundToTwo = (n) => Math.round(n * 1e2) / 1e2;
+const roundToTwo = n => Math.round(n * 1e2) / 1e2;
 
 const MIN_PLAYBACK_SPEED = 0.07;
 const MAX_PLAYBACK_SPEED = 16;
 
 let playbackSpeed = 1;
-
-const computePlayBackSpeed = (playbackSpeedPercentage) => playbackSpeedPercentage || MIN_PLAYBACK_SPEED;
 
 const updatePlayBackSpeed = () => {
 	$('video').playbackRate = playbackSpeed;
@@ -71,8 +69,8 @@ const setupWheelListener = () => {
 }
 
 function setupSliderListener() {
-	$('#playback-speed-slider').addEventListener('immediate-value-changed', () => {
-		playbackSpeed = computePlayBackSpeed($('#playback-speed-slider #sliderBar').value);
+	$('#playback-speed-slider').addEventListener('immediate-value-changed', e => {
+		playbackSpeed = e.detail.value || MIN_PLAYBACK_SPEED;
 		if (isNaN(playbackSpeed)) {
 			playbackSpeed = 1;
 		}

--- a/plugins/precise-volume/front.js
+++ b/plugins/precise-volume/front.js
@@ -39,13 +39,13 @@ function firstRun(options) {
 function injectVolumeHud(noVid) {
 	if (noVid) {
 		const position = "top: 18px; right: 60px; z-index: 999; position: absolute;";
-		const mainStyle = "font-size: xx-large; padding: 10px; transition: opacity 1s";
+		const mainStyle = "font-size: xx-large; padding: 10px; transition: opacity 1s; pointer-events: none;";
 
 		$(".center-content.ytmusic-nav-bar").insertAdjacentHTML("beforeend",
 			`<span id="volumeHud" style="${position + mainStyle}"></span>`)
 	} else {
 		const position = `top: 10px; left: 10px; z-index: 999; position: absolute;`;
-		const mainStyle = "font-size: xxx-large; padding: 10px; transition: opacity 0.6s; webkit-text-stroke: 1px black; font-weight: 600;";
+		const mainStyle = "font-size: xxx-large; padding: 10px; transition: opacity 0.6s; webkit-text-stroke: 1px black; font-weight: 600; pointer-events: none;";
 
 		$("#song-video").insertAdjacentHTML('afterend',
 			`<span id="volumeHud" style="${position + mainStyle}"></span>`)

--- a/plugins/video-toggle/front.js
+++ b/plugins/video-toggle/front.js
@@ -6,12 +6,9 @@ function $(selector) { return document.querySelector(selector); }
 
 let options, player, video, api;
 
-let api;
-
 const switchButtonDiv = ElementFromFile(
     templatePath(__dirname, "button_template.html")
 );
-
 
 module.exports = (_options) => {
     if (_options.forceHide) return;

--- a/plugins/video-toggle/front.js
+++ b/plugins/video-toggle/front.js
@@ -20,7 +20,7 @@ module.exports = (_options) => {
 function setup() {
     $('ytmusic-player-page').prepend(switchButtonDiv);
 
-    $('#song-image.ytmusic-player').style.display = "block"
+    $('#song-image.ytmusic-player').style.display = "block";
 
     if (options.hideVideo) {
         $('.video-switch-button-checkbox').checked = false;
@@ -39,29 +39,35 @@ function setup() {
 }
 
 function changeDisplay(showVideo) {
-    if (!showVideo && $('ytmusic-player').getAttribute('playback-mode') !== "ATV_PREFERRED") {
+    if (!showVideo) {
         $('video').style.top = "0";
-        $('ytmusic-player').style.margin = "auto 21.5px";
+        $('ytmusic-player').style.margin = "auto 0px";
         $('ytmusic-player').setAttribute('playback-mode', "ATV_PREFERRED");
-    }
-
-    showVideo ?
-        $('#song-video.ytmusic-player').style.display = "unset" :
         $('#song-video.ytmusic-player').style.display = "none";
+    } else {
+        $('#song-video.ytmusic-player').style.display = "unset";
+        // fix black video
+        $('video').pause(); $('video').play();
+    }
 }
 
 function videoStarted() {
     if (videoExist()) {
+        // switch to high res thumbnail
         const thumbnails = $('#movie_player').getPlayerResponse()?.videoDetails?.thumbnail?.thumbnails;
         if (thumbnails && thumbnails.length > 0) {
-            $('#song-image img').src = thumbnails[thumbnails.length-1].url;
+            $('#song-image img').src = thumbnails[thumbnails.length - 1].url;
         }
+        // show toggle button
         switchButtonDiv.style.display = "initial";
+        // change display to video mode if video exist & video is hidden & option.hideVideo = false
         if (!options.hideVideo && $('#song-video.ytmusic-player').style.display === "none") {
             changeDisplay(true);
         }
     } else {
+        // video doesn't exist -> switch to song mode
         changeDisplay(false);
+        // hide toggle button
         switchButtonDiv.style.display = "none";
     }
 }
@@ -75,11 +81,11 @@ function videoExist() {
 function forcePlaybackMode() {
     const playbackModeObserver = new MutationObserver(mutations => {
         mutations.forEach(mutation => {
-            if (mutation.type === 'attributes' && mutation.attributeName === 'playback-mode' && mutation.target.getAttribute('playback-mode') !== "ATV_PREFERRED") {
+            if (mutation.target.getAttribute('playback-mode') !== "ATV_PREFERRED") {
                 playbackModeObserver.disconnect();
                 mutation.target.setAttribute('playback-mode', "ATV_PREFERRED");
             }
         });
     });
-    playbackModeObserver.observe($('ytmusic-player'), { attributeFilter: ["playback-mode"] })
+    playbackModeObserver.observe($('ytmusic-player'), { attributeFilter: ["playback-mode"] });
 }

--- a/plugins/video-toggle/front.js
+++ b/plugins/video-toggle/front.js
@@ -21,7 +21,7 @@ function setup(e) {
     api = e.detail;
     player = $('ytmusic-player');
     video = $('video');
-    
+
     $('ytmusic-player-page').prepend(switchButtonDiv);
 
     $('#song-image.ytmusic-player').style.display = "block";
@@ -48,7 +48,10 @@ function changeDisplay(showVideo) {
     player.style.margin = showVideo ? '' : 'auto 0px';
     player.setAttribute('playback-mode', showVideo ? 'OMV_PREFERRED' : 'ATV_PREFERRED');
     $('#song-video.ytmusic-player').style.display = showVideo ? 'unset' : 'none';
-    if(showVideo && !video.style.top) video.style.top = `${(player.clientHeight - video.clientHeight) / 2}px`;
+    if (showVideo && !video.style.top) {
+        video.style.top = `${(player.clientHeight - video.clientHeight) / 2}px`;
+    }
+    moveVolumeHud(showVideo);
 }
 
 function videoStarted() {
@@ -63,6 +66,8 @@ function videoStarted() {
         // change display to video mode if video exist & video is hidden & option.hideVideo = false
         if (!options.hideVideo && $('#song-video.ytmusic-player').style.display === "none") {
             changeDisplay(true);
+        } else {
+            moveVolumeHud(!options.hideVideo);
         }
     } else {
         // video doesn't exist -> switch to song mode
@@ -84,4 +89,11 @@ function forcePlaybackMode() {
         });
     });
     playbackModeObserver.observe(player, { attributeFilter: ["playback-mode"] });
+}
+
+// if precise volume plugin is enabled, move its hud to be on top of the video
+function moveVolumeHud(showVideo) {
+    const volumeHud = $('#volumeHud');
+    if (volumeHud)
+        volumeHud.style.top = showVideo ? `${(player.clientHeight - video.clientHeight) / 2}px` : 0;
 }

--- a/providers/song-controls.js
+++ b/providers/song-controls.js
@@ -13,8 +13,8 @@ module.exports = (win) => {
 		previous: () => pressKey(win, "k"),
 		next: () => pressKey(win, "j"),
 		playPause: () => pressKey(win, "space"),
-		like: () => pressKey(win, "_"),
-		dislike: () => pressKey(win, "+"),
+		like: () => pressKey(win, "+"),
+		dislike: () => pressKey(win, "_"),
 		go10sBack: () => pressKey(win, "h"),
 		go10sForward: () => pressKey(win, "l"),
 		go1sBack: () => pressKey(win, "h", ["shift"]),
@@ -24,8 +24,6 @@ module.exports = (win) => {
 		// General
 		volumeMinus10: () => pressKey(win, "-"),
 		volumePlus10: () => pressKey(win, "="),
-		dislikeAndNext: () => pressKey(win, "-", ["shift"]),
-		like: () => pressKey(win, "=", ["shift"]),
 		fullscreen: () => pressKey(win, "f"),
 		muteUnmute: () => pressKey(win, "m"),
 		maximizeMinimisePlayer: () => pressKey(win, "q"),
@@ -38,13 +36,13 @@ module.exports = (win) => {
 			pressKey(win, "g");
 			pressKey(win, "l");
 		},
-		goToHotlist: () => {
-			pressKey(win, "g");
-			pressKey(win, "t");
-		},
 		goToSettings: () => {
 			pressKey(win, "g");
 			pressKey(win, ",");
+		},
+		goToExplore: () => {
+			pressKey(win, "g");
+			pressKey(win, "e");
 		},
 		search: () => pressKey(win, "/"),
 		showShortcuts: () => pressKey(win, "/", ["shift"]),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2903,10 +2903,10 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
-custom-electron-prompt@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/custom-electron-prompt/-/custom-electron-prompt-1.3.0.tgz#33a46af79c6abceba5640a294e6138756fa44131"
-  integrity sha512-aflX6M9kyB5hsEY3bV7U6PAuCZfaHnI4v95WNTs3foJhlvERBFkqjcAYurIxJ2qnVHyGh/8hRlCtZzEJ4Av0iw==
+custom-electron-prompt@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/custom-electron-prompt/-/custom-electron-prompt-1.3.1.tgz#5c5c1266bb94ca618c493bdbebef2732286a06f2"
+  integrity sha512-QKq0H87G1EQS6QEc1lNmPrMj+J/h/1F4BAcmH2UQ+JUX9MOHZKZvbuIMEdsjYHlgI42SUAcnQklJ9F18ZCAc3A==
 
 custom-electron-titlebar@^3.2.7:
   version "3.2.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2903,10 +2903,10 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
-custom-electron-prompt@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/custom-electron-prompt/-/custom-electron-prompt-1.2.0.tgz#6bf5d00221291f9b886b8052e82d68e296383e68"
-  integrity sha512-+AgL6JMzR91zaPdbZIMEOO2DVAHVGeZQbWpQl/v+XCAVzOaj26B6IwVg96VuYsCewGMuHK7mF3LbWWoLoOe/kQ==
+custom-electron-prompt@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/custom-electron-prompt/-/custom-electron-prompt-1.3.0.tgz#33a46af79c6abceba5640a294e6138756fa44131"
+  integrity sha512-aflX6M9kyB5hsEY3bV7U6PAuCZfaHnI4v95WNTs3foJhlvERBFkqjcAYurIxJ2qnVHyGh/8hRlCtZzEJ4Av0iw==
 
 custom-electron-titlebar@^3.2.7:
   version "3.2.7"


### PR DESCRIPTION
* [Fix](https://github.com/th-ch/youtube-music/pull/476/commits/719c244e3221c857bcf57669c8202903f46d7e26) discord clearing activity on minimize to tray - Fixes #472 

* Refactor video-toggle plugin & fix 2 bugs within it:
  * black video if started in song mode while video exist
  * weird aspect ratio of image in rare edge case (fixed by removing conditions from the if in[ `changeDisplay()`](https://github.com/th-ch/youtube-music/blob/72b43980241671bde22a2fe7f48e62f20962d732/plugins/video-toggle/front.js#L42))
    > steps to reproduce bug: switch to video mode -> switch to song without video -> restart/refresh app, -> switch to song with video -> switch to song mode)

* Fix precise-volume hud blocking the video-toggle button by moving the hud from video-toggle plugin (if it exists)

* Tiny [refactor/lint](https://github.com/th-ch/youtube-music/pull/476/commits/bbece751c0b5c8e78bbc1dcc5455eb190c219a8a) to playback-speed plugin

* [Fix](https://github.com/th-ch/youtube-music/pull/476/commits/071799c435dcaa69beaa15d0441c70c02d4e3c3a) some shortcuts based on current [shortcuts mapping](https://user-images.githubusercontent.com/78568641/141480582-e31a39cc-74c3-4868-a69c-cc91fa225eed.png) (press `shift`+`/` to see all shortcuts available)

* update `custom-electron-prompt` library to v1.3.1 which fixes 2 bugs:
  * 'precise-volume' custom volume prompt crashing on start (see #500)
  * Backquotes(`` ` ``) were interpreted as normal quote (` " `) in shortcut prompt (see #499)
 
* [Fix ](https://github.com/th-ch/youtube-music/pull/476/commits/eafdd5046dcc1581335d243d9ef931d6fa3410ca)tiny text size of lyrics (test and see if it looks fine to you? I'm not actually sure about this one)