### PR TITLE
Fix loadeddata/metadata video events rarely not firing (+other small fixes)

### DIFF
--- a/plugins/disable-autoplay/front.js
+++ b/plugins/disable-autoplay/front.js
@@ -1,7 +1,14 @@
 module.exports = () => {
-	document.addEventListener('apiLoaded', e => {
-		document.querySelector('video').addEventListener('srcChanged', () => {
-			e.detail.pauseVideo();
+	document.addEventListener('apiLoaded', apiEvent => {
+		apiEvent.detail.addEventListener('videodatachange', name => {
+			if (name === 'dataloaded') {
+				apiEvent.detail.pauseVideo();
+				document.querySelector('video').ontimeupdate = e => {
+					e.target.pause();
+				}
+			} else {
+				document.querySelector('video').ontimeupdate = null;
+		   }
 		})
 	}, { once: true, passive: true })
 };

--- a/plugins/disable-autoplay/front.js
+++ b/plugins/disable-autoplay/front.js
@@ -1,7 +1,7 @@
 module.exports = () => {
-	document.addEventListener('apiLoaded', () => {
-		document.querySelector('video').addEventListener('srcChanged', e => {
-			e.target.pause();
+	document.addEventListener('apiLoaded', e => {
+		document.querySelector('video').addEventListener('srcChanged', () => {
+			e.detail.pauseVideo();
 		})
 	}, { once: true, passive: true })
 };

--- a/plugins/disable-autoplay/front.js
+++ b/plugins/disable-autoplay/front.js
@@ -1,6 +1,6 @@
 module.exports = () => {
 	document.addEventListener('apiLoaded', () => {
-		document.querySelector('video').addEventListener('loadeddata', e => {
+		document.querySelector('video').addEventListener('srcChanged', e => {
 			e.target.pause();
 		})
 	}, { once: true, passive: true })

--- a/plugins/playback-speed/front.js
+++ b/plugins/playback-speed/front.js
@@ -49,7 +49,7 @@ const observePopupContainer = () => {
 
 const observeVideo = () => {
 	$('video').addEventListener('ratechange', forcePlaybackRate)
-	$('video').addEventListener('loadeddata', forcePlaybackRate)
+	$('video').addEventListener('srcChanged', forcePlaybackRate)
 }
 
 const setupWheelListener = () => {

--- a/plugins/sponsorblock/back.js
+++ b/plugins/sponsorblock/back.js
@@ -1,8 +1,8 @@
 const fetch = require("node-fetch");
 const is = require("electron-is");
+const { ipcMain } = require("electron");
 
 const defaultConfig = require("../../config/defaults");
-const registerCallback = require("../../providers/song-info");
 const { sortSegments } = require("./segments");
 
 let videoID;
@@ -13,15 +13,10 @@ module.exports = (win, options) => {
 		...options,
 	};
 
-	registerCallback(async (info) => {
-		const newURL = info.url || win.webContents.getURL();
-		const newVideoID = new URL(newURL).searchParams.get("v");
-
-		if (videoID !== newVideoID) {
-			videoID = newVideoID;
-			const segments = await fetchSegments(apiURL, categories);
-			win.webContents.send("sponsorblock-skip", segments);
-		}
+	ipcMain.on("song-info-request", async (_, data) => {
+		videoID = JSON.parse(data)?.videoDetails?.videoId;
+		const segments = await fetchSegments(apiURL, categories);
+		win.webContents.send("sponsorblock-skip", segments);
 	});
 };
 

--- a/plugins/sponsorblock/back.js
+++ b/plugins/sponsorblock/back.js
@@ -13,7 +13,7 @@ module.exports = (win, options) => {
 		...options,
 	};
 
-	ipcMain.on("song-info-request", async (_, data) => {
+	ipcMain.on("video-src-changed", async (_, data) => {
 		videoID = JSON.parse(data)?.videoDetails?.videoId;
 		const segments = await fetchSegments(apiURL, categories);
 		win.webContents.send("sponsorblock-skip", segments);

--- a/plugins/video-toggle/front.js
+++ b/plugins/video-toggle/front.js
@@ -35,13 +35,13 @@ function setup() {
         setOptions("video-toggle", options);
     })
 
-    $('video').addEventListener('loadedmetadata', videoStarted);
+    $('video').addEventListener('srcChanged', videoStarted);
 }
 
 function changeDisplay(showVideo) {
-    if (!showVideo && $('ytmusic-player').getAttribute('playback-mode') !== "ATV_PREFERRED") {
+    if (!showVideo) {
         $('video').style.top = "0";
-        $('ytmusic-player').style.margin = "auto 21.5px";
+        $('ytmusic-player').style.margin = "auto 0px";
         $('ytmusic-player').setAttribute('playback-mode', "ATV_PREFERRED");
     }
 

--- a/plugins/video-toggle/front.js
+++ b/plugins/video-toggle/front.js
@@ -98,6 +98,6 @@ function observeThumbnail() {
 function forceThumbnail(img) {
     const thumbnails = $('#movie_player').getPlayerResponse()?.videoDetails?.thumbnail?.thumbnails;
     if (thumbnails && thumbnails.length > 0) {
-        img.src = thumbnails[thumbnails.length - 1].url;
+        img.src = thumbnails[thumbnails.length - 1].url.split("?")[0];
     }
 }

--- a/providers/song-info-front.js
+++ b/providers/song-info-front.js
@@ -16,11 +16,19 @@ module.exports = () => {
 	document.addEventListener('apiLoaded', apiEvent => {
 		const video = document.querySelector('video');
 		// name = "dataloaded" and abit later "dataupdated"
-		apiEvent.detail.addEventListener('videodatachange', (name, dataEvent) => {
+		apiEvent.detail.addEventListener('videodatachange', (name, _dataEvent) => {
 			if (name !== 'dataloaded') return;
 			video.dispatchEvent(srcChangedEvent);
-			ipcRenderer.send("song-info-request", JSON.stringify(dataEvent.playerResponse));
+			ipcRenderer.send("video-src-changed", JSON.stringify(apiEvent.detail.getPlayerResponse()));
 		})
-
+		for (const status of ['playing', 'pause']) {
+			video.addEventListener(status, sendSongInfo);
+		}
+		function sendSongInfo() {
+			const data = apiEvent.detail.getPlayerResponse();
+			data.videoDetails.elapsedSeconds = Math.floor(video.currentTime);
+			data.videoDetails.isPaused = video.paused;
+			ipcRenderer.send("song-info-request", JSON.stringify(apiEvent.detail.getPlayerResponse()));
+		}
 	}, { once: true, passive: true });
 };

--- a/providers/song-info-front.js
+++ b/providers/song-info-front.js
@@ -10,10 +10,22 @@ ipcRenderer.on("update-song-info", async (_, extractedSongInfo) => {
 });
 
 module.exports = () => {
-	document.addEventListener('apiLoaded', e => {
-		document.querySelector('video').addEventListener('loadedmetadata', () => {
-			const data = e.detail.getPlayerResponse();
-			ipcRenderer.send("song-info-request", JSON.stringify(data));
-		});
-	}, { once: true, passive: true })
+	document.addEventListener('apiLoaded', e => observeSrcChange(e.detail), { once: true, passive: true });
 };
+
+// used because 'loadeddata' or 'loadedmetadata' weren't firing on song start for some users (https://github.com/th-ch/youtube-music/issues/473)
+function observeSrcChange(api) {
+	const srcChangedEvent = new CustomEvent('srcChanged');
+
+	const video = document.querySelector('video');
+
+	const playbackModeObserver = new MutationObserver((mutations) => {
+		mutations.forEach(mutation => {
+			if (mutation.target.src) { // in first mutation src is usually an empty string (loading)
+				video.dispatchEvent(srcChangedEvent);
+				ipcRenderer.send("song-info-request", JSON.stringify(api.getPlayerResponse()));
+			}
+		})
+	});
+	playbackModeObserver.observe(video, { attributeFilter: ["src"] })
+}

--- a/providers/song-info-front.js
+++ b/providers/song-info-front.js
@@ -18,8 +18,8 @@ module.exports = () => {
 		// name = "dataloaded" and abit later "dataupdated"
 		apiEvent.detail.addEventListener('videodatachange', (name, dataEvent) => {
 			if (name !== 'dataloaded') return;
-			ipcRenderer.send("song-info-request", JSON.stringify(dataEvent.playerResponse));
 			video.dispatchEvent(srcChangedEvent);
+			ipcRenderer.send("song-info-request", JSON.stringify(dataEvent.playerResponse));
 		})
 
 	}, { once: true, passive: true });

--- a/providers/song-info-front.js
+++ b/providers/song-info-front.js
@@ -22,21 +22,22 @@ module.exports = () => {
 			sendSongInfo();
 		})
 
-		video.addEventListener('pause', e => {
-			ipcRenderer.send("playPaused", { isPaused: true, elapsedSeconds: Math.floor(e.target.currentTime) });
-		});
-
-		video.addEventListener('playing', e => {
-			if (e.target.currentTime > 0){
-				ipcRenderer.send("playPaused", { isPaused: false, elapsedSeconds: Math.floor(e.target.currentTime) });
-			}
-		});
+		for (const status of ['playing', 'pause']) {
+			video.addEventListener(status, e => {
+				if (Math.floor(e.target.currentTime) > 0) {
+					ipcRenderer.send("playPaused", {
+						isPaused: status === 'pause',
+						elapsedSeconds: Math.floor(e.target.currentTime)
+					});
+				}
+			});
+		}
 
 		function sendSongInfo() {
 			const data = apiEvent.detail.getPlayerResponse();
 			data.videoDetails.elapsedSeconds = Math.floor(video.currentTime);
-			data.videoDetails.isPaused = video.paused;
-			ipcRenderer.send("video-src-changed", JSON.stringify(apiEvent.detail.getPlayerResponse()));
+			data.videoDetails.isPaused = false;
+			ipcRenderer.send("video-src-changed", JSON.stringify(data));
 		}
 	}, { once: true, passive: true });
 };

--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -86,12 +86,19 @@ const registerCallback = (callback) => {
 
 const registerProvider = (win) => {
 	// This will be called when the song-info-front finds a new request with song data
-	ipcMain.on("song-info-request", async (_, responseText) => {
+	ipcMain.on("video-src-changed", async (_, responseText) => {
 		await handleData(responseText, win);
 		callbacks.forEach((c) => {
 			c(songInfo);
 		});
 	});
+	ipcMain.on("playPaused", (_, { isPaused, elapsedSeconds }) => {
+		songInfo.isPaused = isPaused;
+		songInfo.elapsedSeconds = elapsedSeconds;
+		callbacks.forEach((c) => {
+			c(songInfo);
+		});
+	})
 };
 
 const suffixesToRemove = [

--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -4,32 +4,6 @@ const fetch = require("node-fetch");
 
 const config = require("../config");
 
-// Grab the progress using the selector
-const getProgress = async (win) => {
-	// Get current value of the progressbar element
-	return win.webContents.executeJavaScript(
-		'document.querySelector("#progress-bar").value'
-	);
-};
-
-// Grab the native image using the src
-const getImage = async (src) => {
-	const result = await fetch(src);
-	const buffer = await result.buffer();
-	const output = nativeImage.createFromBuffer(buffer);
-	if (output.isEmpty() && !src.endsWith(".jpg") && src.includes(".jpg")) { // fix hidden webp files (https://github.com/th-ch/youtube-music/issues/315)
-		return getImage(src.slice(0, src.lastIndexOf(".jpg")+4));
-	} else {
-		return output;
-	}
-};
-
-// To find the paused status, we check if the title contains `-`
-const getPausedStatus = async (win) => {
-	const title = await win.webContents.executeJavaScript("document.title");
-	return !title.includes("-");
-};
-
 // Fill songInfo with empty values
 /**
  * @typedef {songInfo} SongInfo
@@ -47,21 +21,48 @@ const songInfo = {
 	url: "",
 };
 
+// Grab the native image using the src
+const getImage = async (src) => {
+	const result = await fetch(src);
+	const buffer = await result.buffer();
+	const output = nativeImage.createFromBuffer(buffer);
+	if (output.isEmpty() && !src.endsWith(".jpg") && src.includes(".jpg")) { // fix hidden webp files (https://github.com/th-ch/youtube-music/issues/315)
+		return getImage(src.slice(0, src.lastIndexOf(".jpg") + 4));
+	} else {
+		return output;
+	}
+};
+
 const handleData = async (responseText, win) => {
-	let data = JSON.parse(responseText);
-	songInfo.title = cleanupName(data?.videoDetails?.title);
-	songInfo.artist =cleanupName(data?.videoDetails?.author);
-	songInfo.views = data?.videoDetails?.viewCount;
-	songInfo.imageSrc = data?.videoDetails?.thumbnail?.thumbnails?.pop()?.url.split("?")[0];
-	songInfo.songDuration = data?.videoDetails?.lengthSeconds;
-	songInfo.image = await getImage(songInfo.imageSrc);
-	songInfo.uploadDate = data?.microformat?.microformatDataRenderer?.uploadDate;
-	songInfo.url = data?.microformat?.microformatDataRenderer?.urlCanonical?.split("&")[0];
+	const data = JSON.parse(responseText);
+	if (!data) return;
 
-	// used for options.resumeOnStart
-	config.set("url", data?.microformat?.microformatDataRenderer?.urlCanonical);
+	const microformat = data.microformat?.microformatDataRenderer;
+	if (microformat) {
+		songInfo.uploadDate = microformat.uploadDate;
+		songInfo.url = microformat.urlCanonical?.split("&")[0];
 
-	win.webContents.send("update-song-info", JSON.stringify(songInfo));
+		// used for options.resumeOnStart
+		config.set("url", microformat.urlCanonical);
+	}
+
+	const videoDetails = data.videoDetails;
+	if (videoDetails) {
+		songInfo.title = cleanupName(videoDetails.title);
+		songInfo.artist = cleanupName(videoDetails.author);
+		songInfo.views = videoDetails.viewCount;
+		songInfo.songDuration = videoDetails.lengthSeconds;
+		songInfo.elapsedSeconds = videoDetails.elapsedSeconds;
+		songInfo.isPaused = videoDetails.isPaused;
+
+		const oldUrl = songInfo.imageSrc;
+		songInfo.imageSrc = videoDetails.thumbnail?.thumbnails?.pop()?.url.split("?")[0];
+		if (oldUrl !== songInfo.imageSrc) {
+			songInfo.image = await getImage(songInfo.imageSrc);
+		}
+
+		win.webContents.send("update-song-info", JSON.stringify(songInfo));
+	}
 };
 
 // This variable will be filled with the callbacks once they register
@@ -81,19 +82,6 @@ const registerCallback = (callback) => {
 };
 
 const registerProvider = (win) => {
-	win.on("page-title-updated", async () => {
-		// Get and set the new data
-		songInfo.isPaused = await getPausedStatus(win);
-
-		const elapsedSeconds = await getProgress(win);
-		songInfo.elapsedSeconds = elapsedSeconds;
-
-		// Trigger the callbacks
-		callbacks.forEach((c) => {
-			c(songInfo);
-		});
-	});
-
 	// This will be called when the song-info-front finds a new request with song data
 	ipcMain.on("song-info-request", async (_, responseText) => {
 		await handleData(responseText, win);
@@ -114,7 +102,7 @@ const suffixesToRemove = [
 
 function cleanupName(name) {
 	if (!name) return name;
-    const lowCaseName = name.toLowerCase();
+	const lowCaseName = name.toLowerCase();
 	for (const suffix of suffixesToRemove) {
 		if (lowCaseName.endsWith(suffix)) {
 			return name.slice(0, -suffix.length);

--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -52,7 +52,7 @@ const handleData = async (responseText, win) => {
 	songInfo.title = cleanupName(data?.videoDetails?.title);
 	songInfo.artist =cleanupName(data?.videoDetails?.author);
 	songInfo.views = data?.videoDetails?.viewCount;
-	songInfo.imageSrc = data?.videoDetails?.thumbnail?.thumbnails?.pop()?.url;
+	songInfo.imageSrc = data?.videoDetails?.thumbnail?.thumbnails?.pop()?.url.split("?")[0];
 	songInfo.songDuration = data?.videoDetails?.lengthSeconds;
 	songInfo.image = await getImage(songInfo.imageSrc);
 	songInfo.uploadDate = data?.microformat?.microformatDataRenderer?.uploadDate;

--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -19,6 +19,8 @@ const songInfo = {
 	songDuration: 0,
 	elapsedSeconds: 0,
 	url: "",
+	videoId: "",
+	playlistId: "",
 };
 
 // Grab the native image using the src
@@ -41,7 +43,7 @@ const handleData = async (responseText, win) => {
 	if (microformat) {
 		songInfo.uploadDate = microformat.uploadDate;
 		songInfo.url = microformat.urlCanonical?.split("&")[0];
-
+		songInfo.playlistId = new URL(microformat.urlCanonical).searchParams.get("list");
 		// used for options.resumeOnStart
 		config.set("url", microformat.urlCanonical);
 	}
@@ -54,6 +56,7 @@ const handleData = async (responseText, win) => {
 		songInfo.songDuration = videoDetails.lengthSeconds;
 		songInfo.elapsedSeconds = videoDetails.elapsedSeconds;
 		songInfo.isPaused = videoDetails.isPaused;
+		songInfo.videoId = videoDetails.videoId;
 
 		const oldUrl = songInfo.imageSrc;
 		songInfo.imageSrc = videoDetails.thumbnail?.thumbnails?.pop()?.url.split("?")[0];


### PR DESCRIPTION
Fix #473 
I've been testing stuff with @FiestaLake over on discord

it seems some users had a bug with the video events: `dataloaded` or `metadataloaded` not firing, and also the ` video.src` property wasn't changing,

this PR makes use of the api's `videodatachange` event (specifically when its internal name is `dataloaded`) and populates it on the video element so that it can be accessed easily with the new `srcChanged` video  event
(This allows plugins to know when a new video started in a bug free way)

this PR also change the way songInfo send callbacks (page-title update was messy, would send alot of updates for no reason)
now songInfo is sent everytime playback is started and `isPaused` + `elapsedSeconds` are updated when playback is paused\unpaused\seeked

## Other small included fixes

- fix a grey thumbnail issue that occasionally occurred in video-toggle plugin because the `thumbnail.src` was overridden by the website after it was set programmatically (fixed using a mutation observer)

- fix weird aspect ratio of thumbnail in song-info and video-toggle using `url.split("?")[0]` to filter query from thumbnail-url that resulted in cropped thumbnails 
  (only when a video is present and the url is `i.ytimg.com/vi/videoid/quality.jpg?query` and not when the player is in song mode and the url is `lh3.googleusercontent.com/verylongid=w544-h544-l90-rj`)

- speed up sponsorblock plugin by using `ipcMain.on("video-src-changed")` instead of `registerCallback()`  (which is slower)

-  185ebbf **fix** playlist downloading that was broken in last update (fix #497) 
   it also changes the default way of getting the playlistId to 'Currently-Shown-Playlist OR Currently-Playing-Playlist' (it was the other way around before which made less sense IMO)

-  fix disable-autoplay plugin for some people with slower internet, below is a short explanation of how it works:
  https://github.com/th-ch/youtube-music/blob/92452f804f62f19b12f31bcfbf579191006ce85c/plugins/disable-autoplay/front.js#L3-L12
  on video start 2 events are always sent, `dataloaded` first and then `dataupdated`. the video tries to start between these 2 events and thats why it pauses on time update between them. (this is method is independent of internet speed)
  also its important to note that `dataloaded` is **only** happen on video load while `dataupdated` **might** happen at other times