### PR TITLE
Mpris + obs-tuna fixes

### DIFF
--- a/plugins/shortcuts/back.js
+++ b/plugins/shortcuts/back.js
@@ -68,9 +68,8 @@ function registerShortcuts(win, options) {
 
 			const player = setupMPRIS();
 
-			const mprisSeek = p => {
-				player.seeked(p);
-			}
+			const mprisSeek = player.seeked;
+
 			win.webContents.send("registerOnSeek");
 
 			ipcMain.on('seeked', (_, t) => mprisSeek(secToMicro(t)));
@@ -107,13 +106,15 @@ function registerShortcuts(win, options) {
 
 			registerCallback(songInfo => {
 				if (player) {
-					player.metadata = {
+					const data = {
 						'mpris:length': secToMicro(songInfo.songDuration),
 						'mpris:artUrl': songInfo.imageSrc,
 						'xesam:title': songInfo.title,
 						'xesam:artist': songInfo.artist,
 						'mpris:trackid': '/'
-					};;
+					};
+					if (songInfo.album) data['xesam:album'] = songInfo.album;
+					player.metadata = data;
 					mprisSeek(secToMicro(songInfo.elapsedSeconds))
 					player.playbackStatus = songInfo.isPaused ? "Paused" : "Playing"
 				}

--- a/plugins/shortcuts/back.js
+++ b/plugins/shortcuts/back.js
@@ -1,9 +1,8 @@
-const { globalShortcut, ipcMain } = require("electron");
+const { globalShortcut } = require("electron");
 const is = require("electron-is");
 const electronLocalshortcut = require("electron-localshortcut");
 const getSongControls = require("../../providers/song-controls");
-const { setupMPRIS } = require("./mpris");
-const registerCallback = require("../../providers/song-info");
+const registerMPRIS = require("./mpris");
 
 function _registerGlobalShortcut(webContents, shortcut, action) {
 	globalShortcut.register(shortcut, () => {
@@ -30,7 +29,7 @@ function registerShortcuts(win, options) {
 	_registerLocalShortcut(win, "CommandOrControl+F", search);
 	_registerLocalShortcut(win, "CommandOrControl+L", search);
 
-	if (is.linux()) registerMPRIS();
+	if (is.linux()) registerMPRIS(win);
 
 	const { global, local } = options;
 	const shortcutOptions = { global, local };
@@ -56,72 +55,6 @@ function registerShortcuts(win, options) {
 			} else { // type === "local"
 				_registerLocalShortcut(win, local[action], songControls[action]);
 			}
-		}
-	}
-	function registerMPRIS() {
-		try {
-			const secToMicro = n => Math.round(Number(n) * (1000 * 1000));
-			const microToSec = n => Math.round(Number(n) / 1000 / 1000);
-
-			const seekTo = e => win.webContents.send("seekTo", microToSec(e.position));
-			const seek = o => win.webContents.send("seek", microToSec(o));
-
-			const player = setupMPRIS();
-
-			const mprisSeek = player.seeked;
-
-			win.webContents.send("registerOnSeek");
-
-			ipcMain.on('seeked', (_, t) => mprisSeek(secToMicro(t)));
-
-			let currentSeconds = 0;
-			ipcMain.on('timeChanged', (_, t) => currentSeconds = t);
-
-			player.getPosition = () => secToMicro(currentSeconds)
-
-			player.on("raise", () => {
-				win.setSkipTaskbar(false);
-				win.show();
-			});
-
-			player.on("play", () => {
-				if (player.playbackStatus !== 'Playing') {
-					player.playbackStatus = 'Playing';
-					playPause()
-				}
-			});
-			player.on("pause", () => {
-				if (player.playbackStatus !== 'Paused') {
-					player.playbackStatus = 'Paused';
-					playPause()
-				}
-			});
-
-			player.on("playpause", playPause);
-			player.on("next", next);
-			player.on("previous", previous);
-
-			player.on('seek', seek);
-			player.on('position', seekTo);
-
-			registerCallback(songInfo => {
-				if (player) {
-					const data = {
-						'mpris:length': secToMicro(songInfo.songDuration),
-						'mpris:artUrl': songInfo.imageSrc,
-						'xesam:title': songInfo.title,
-						'xesam:artist': songInfo.artist,
-						'mpris:trackid': '/'
-					};
-					if (songInfo.album) data['xesam:album'] = songInfo.album;
-					player.metadata = data;
-					mprisSeek(secToMicro(songInfo.elapsedSeconds))
-					player.playbackStatus = songInfo.isPaused ? "Paused" : "Playing"
-				}
-			})
-
-		} catch (e) {
-			console.warn("Error in MPRIS", e);
 		}
 	}
 }

--- a/plugins/shortcuts/mpris.js
+++ b/plugins/shortcuts/mpris.js
@@ -1,4 +1,6 @@
 const mpris = require("mpris-service");
+const { ipcMain } = require("electron");
+const registerCallback = require("../../providers/song-info");
 
 function setupMPRIS() {
 	const player = mpris({
@@ -14,6 +16,71 @@ function setupMPRIS() {
 	return player;
 }
 
-module.exports = {
-	setupMPRIS,
-};
+function registerMPRIS(win) {
+	try {
+		const secToMicro = n => Math.round(Number(n) * 1e6);
+		const microToSec = n => Math.round(Number(n) / 1e6);
+
+		const seekTo = e => win.webContents.send("seekTo", microToSec(e.position));
+		const seek = o => win.webContents.send("seek", microToSec(o));
+
+		const player = setupMPRIS();
+
+		const mprisSeek = player.seeked;
+
+		win.webContents.send("registerOnSeek");
+
+		ipcMain.on('seeked', (_, t) => mprisSeek(secToMicro(t)));
+
+		let currentSeconds = 0;
+		ipcMain.on('timeChanged', (_, t) => currentSeconds = t);
+
+		player.getPosition = () => secToMicro(currentSeconds)
+
+		player.on("raise", () => {
+			win.setSkipTaskbar(false);
+			win.show();
+		});
+
+		player.on("play", () => {
+			if (player.playbackStatus !== 'Playing') {
+				player.playbackStatus = 'Playing';
+				playPause()
+			}
+		});
+		player.on("pause", () => {
+			if (player.playbackStatus !== 'Paused') {
+				player.playbackStatus = 'Paused';
+				playPause()
+			}
+		});
+
+		player.on("playpause", playPause);
+		player.on("next", next);
+		player.on("previous", previous);
+
+		player.on('seek', seek);
+		player.on('position', seekTo);
+
+		registerCallback(songInfo => {
+			if (player) {
+				const data = {
+					'mpris:length': secToMicro(songInfo.songDuration),
+					'mpris:artUrl': songInfo.imageSrc,
+					'xesam:title': songInfo.title,
+					'xesam:artist': songInfo.artist,
+					'mpris:trackid': '/'
+				};
+				if (songInfo.album) data['xesam:album'] = songInfo.album;
+				player.metadata = data;
+				mprisSeek(secToMicro(songInfo.elapsedSeconds))
+				player.playbackStatus = songInfo.isPaused ? "Paused" : "Playing"
+			}
+		})
+
+	} catch (e) {
+		console.warn("Error in MPRIS", e);
+	}
+}
+
+module.exports = registerMPRIS;

--- a/plugins/shortcuts/mpris.js
+++ b/plugins/shortcuts/mpris.js
@@ -22,13 +22,11 @@ function registerMPRIS(win) {
 		const microToSec = n => Math.round(Number(n) / 1e6);
 
 		const seekTo = e => win.webContents.send("seekTo", microToSec(e.position));
-		const seek = o => win.webContents.send("seek", microToSec(o));
+		const seekBy = o => win.webContents.send("seekBy", microToSec(o));
 
 		const player = setupMPRIS();
 
 		const mprisSeek = player.seeked;
-
-		win.webContents.send("registerOnSeek");
 
 		ipcMain.on('seeked', (_, t) => mprisSeek(secToMicro(t)));
 
@@ -59,7 +57,7 @@ function registerMPRIS(win) {
 		player.on("next", next);
 		player.on("previous", previous);
 
-		player.on('seek', seek);
+		player.on('seek', seekBy);
 		player.on('position', seekTo);
 
 		registerCallback(songInfo => {

--- a/plugins/tuna-obs/back.js
+++ b/plugins/tuna-obs/back.js
@@ -1,33 +1,50 @@
-const { ipcRenderer } = require("electron");
+const { ipcMain } = require("electron");
 const fetch = require('node-fetch');
 
 const registerCallback = require("../../providers/song-info");
 
-const post = (data) => {
+const secToMilisec = t => Math.round(Number(t) * 1000);
+const data = {
+	cover_url: '',
+	title: '',
+	artists: [],
+	status: '',
+	progress: 0,
+	duration: 0,
+	album_url: ''
+};
+
+const post = async (data) => {
 	const port = 1608;
-	headers = {'Content-Type': 'application/json',
+	headers = {
+		'Content-Type': 'application/json',
 		'Accept': 'application/json',
 		'Access-Control-Allow-Headers': '*',
-		'Access-Control-Allow-Origin': '*'}
+		'Access-Control-Allow-Origin': '*'
+	}
 	const url = `http://localhost:${port}/`;
-	fetch(url, {method: 'POST', headers, body:JSON.stringify({data})});
+	fetch(url, { method: 'POST', headers, body: JSON.stringify({ data }) });
 }
 
-module.exports = async (win) => {
-	registerCallback((songInfo) => {
+module.exports = async () => {
+	ipcMain.on('timeChanged', async (_, t) => {
+		if (!data.title) return;
+		data.progress = secToMilisec(t);
+		post(data);
+	});
 
-		// Register the callback
-		if (songInfo.title.length === 0 && songInfo.artist.length === 0) {
+	registerCallback((songInfo) => {
+		if (!songInfo.title && !songInfo.artist) {
 			return;
 		}
 
-		const duration =  Number(songInfo.songDuration)*1000
-		const progress = Number(songInfo.elapsedSeconds)*1000
-		const cover_url = songInfo.imageSrc
-		const album_url = songInfo.imageSrc
-		const title = songInfo.title
-		const artists = [songInfo.artist]
-		const status = !songInfo.isPaused ? 'Playing': 'Paused'
-		post({ cover_url, title, artists, status, progress, duration, album_url});
+		data.duration = secToMilisec(songInfo.songDuration)
+		data.progress = secToMilisec(songInfo.elapsedSeconds)
+		data.cover_url = songInfo.imageSrc;
+		data.album_url = songInfo.imageSrc;
+		data.title = songInfo.title;
+		data.artists = [songInfo.artist];
+		data.status = songInfo.isPaused ? 'Paused' : 'Playing';
+		post(data);
 	})
 }

--- a/plugins/tuna-obs/back.js
+++ b/plugins/tuna-obs/back.js
@@ -3,7 +3,7 @@ const fetch = require('node-fetch');
 
 const registerCallback = require("../../providers/song-info");
 
-const secToMilisec = t => Math.round(Number(t) * 1000);
+const secToMilisec = t => Math.round(Number(t) * 1e3);
 const data = {
 	cover_url: '',
 	title: '',

--- a/plugins/tuna-obs/back.js
+++ b/plugins/tuna-obs/back.js
@@ -11,7 +11,8 @@ const data = {
 	status: '',
 	progress: 0,
 	duration: 0,
-	album_url: ''
+	album_url: '',
+	album: undefined
 };
 
 const post = async (data) => {
@@ -44,7 +45,8 @@ module.exports = async () => {
 		data.album_url = songInfo.imageSrc;
 		data.title = songInfo.title;
 		data.artists = [songInfo.artist];
-		data.status = songInfo.isPaused ? 'Paused' : 'Playing';
+		data.status = songInfo.isPaused ? 'stopped' : 'playing';
+		data.album = songInfo.album;
 		post(data);
 	})
 }

--- a/plugins/tuna-obs/back.js
+++ b/plugins/tuna-obs/back.js
@@ -23,7 +23,7 @@ const post = async (data) => {
 		'Access-Control-Allow-Origin': '*'
 	}
 	const url = `http://localhost:${port}/`;
-	fetch(url, { method: 'POST', headers, body: JSON.stringify({ data }) });
+	fetch(url, { method: 'POST', headers, body: JSON.stringify({ data }) }).catch(e => console.log(`Error: '${e.code || e.errno}' - when trying to access obs-tuna webserver at port ${port}`));
 }
 
 module.exports = async () => {

--- a/plugins/tuna-obs/back.js
+++ b/plugins/tuna-obs/back.js
@@ -27,7 +27,7 @@ const post = async (data) => {
 	fetch(url, { method: 'POST', headers, body: JSON.stringify({ data }) }).catch(e => console.log(`Error: '${e.code || e.errno}' - when trying to access obs-tuna webserver at port ${port}`));
 }
 
-module.exports = async () => {
+module.exports = async (win) => {
 	ipcMain.on('timeChanged', async (_, t) => {
 		if (!data.title) return;
 		data.progress = secToMilisec(t);

--- a/preload.js
+++ b/preload.js
@@ -6,6 +6,7 @@ const config = require("./config");
 const { fileExists } = require("./plugins/utils");
 const setupFrontLogger = require("./providers/front-logger");
 const setupSongInfo = require("./providers/song-info-front");
+const { setupSongControls } = require("./providers/song-controls-front");
 
 const plugins = config.plugins.getEnabled();
 
@@ -44,6 +45,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
 	// inject song-info provider
 	setupSongInfo();
+
+	// inject song-controls
+	setupSongControls();
 
 	// inject front logger
 	setupFrontLogger();

--- a/providers/song-controls-front.js
+++ b/providers/song-controls-front.js
@@ -1,30 +1,15 @@
 const { ipcRenderer } = require("electron");
-
-module.exports.seekTo = seekTo;
-function seekTo(t) {
-    document.querySelector('video').currentTime = t;
-}
-
-module.exports.seek = seek;
-function seek(o) {
-    document.querySelector('video').currentTime += o;
-}
+const config = require("../config");
+const is = require("electron-is");
 
 module.exports.setupSongControls = () => {
-	ipcRenderer.on("seekTo", async (_, t) => seekTo(t));
-    ipcRenderer.on("seek", async (_, t) => seek(t));
-    ipcRenderer.once("registerOnSeek", registerOnSeek)
-};
+    document.addEventListener('apiLoaded', e => {
+        ipcRenderer.on("seekTo", (_, t) => e.target.seekTo(t));
+        ipcRenderer.on("seekBy", (_, t) => e.target.seekBy(t));
 
-async function registerOnSeek() {
-    const register = v => v.addEventListener('seeked', () => ipcRenderer.send('seeked', v.currentTime));
-    let video =  document.querySelector('video');
-    if (video) {
-        register(video);
+    }, { once: true, passive: true })
+
+    if (is.linux() && config.plugins.isEnabled('shortcuts')) { // MPRIS Enabled
+        document.querySelector('video').addEventListener('seeked', () => ipcRenderer.send('seeked', v.currentTime));
     }
-    else {
-        document.addEventListener('apiLoaded', () => {
-            register(document.querySelector('video'))
-        }, { once: true, passive: true })
-    }
-}
+};

--- a/providers/song-controls-front.js
+++ b/providers/song-controls-front.js
@@ -1,0 +1,30 @@
+const { ipcRenderer } = require("electron");
+
+module.exports.seekTo = seekTo;
+function seekTo(t) {
+    document.querySelector('video').currentTime = t;
+}
+
+module.exports.seek = seek;
+function seek(o) {
+    document.querySelector('video').currentTime += o;
+}
+
+module.exports.setupSongControls = () => {
+	ipcRenderer.on("seekTo", async (_, t) => seekTo(t));
+    ipcRenderer.on("seek", async (_, t) => seek(t));
+    ipcRenderer.once("registerOnSeek", registerOnSeek)
+};
+
+async function registerOnSeek() {
+    const register = v => v.addEventListener('seeked', () => ipcRenderer.send('seeked', v.currentTime));
+    let video =  document.querySelector('video');
+    if (video) {
+        register(video);
+    }
+    else {
+        document.addEventListener('apiLoaded', () => {
+            register(document.querySelector('video'))
+        }, { once: true, passive: true })
+    }
+}

--- a/providers/song-info-front.js
+++ b/providers/song-info-front.js
@@ -4,6 +4,8 @@ const { getImage } = require("./song-info");
 
 global.songInfo = {};
 
+function $(selector) { return document.querySelector(selector); }
+
 ipcRenderer.on("update-song-info", async (_, extractedSongInfo) => {
 	global.songInfo = JSON.parse(extractedSongInfo);
 	global.songInfo.image = await getImage(global.songInfo.imageSrc);
@@ -13,8 +15,9 @@ module.exports = () => {
 	document.addEventListener('apiLoaded', e => {
 		setupTimeChangeListener();
 
-		document.querySelector('video').addEventListener('loadedmetadata', () => {
+		$('video').addEventListener('loadedmetadata', () => {
 			const data = e.detail.getPlayerResponse();
+			data.videoDetails.album = $('ytmusic-player-page')?.__data?.playerPageWatchMetadata?.albumName?.runs[0].text
 			ipcRenderer.send("song-info-request", JSON.stringify(data));
 		});
 	}, { once: true, passive: true })
@@ -25,5 +28,5 @@ function setupTimeChangeListener() {
 		ipcRenderer.send('timeChanged', mutations[0].target.value);
 		global.songInfo.elapsedSeconds = mutations[0].target.value;
 	});
-	progressObserver.observe(document.querySelector('#progress-bar'), { attributeFilter: ["value"] })
+	progressObserver.observe($('#progress-bar'), { attributeFilter: ["value"] })
 }

--- a/providers/song-info-front.js
+++ b/providers/song-info-front.js
@@ -18,7 +18,7 @@ const srcChangedEvent = new CustomEvent('srcChanged');
 
 module.exports = () => {
 	document.addEventListener('apiLoaded', apiEvent => {
-    if (config.plugins.isEnabled('tuna-obs')) {
+		if (config.plugins.isEnabled('tuna-obs')) {
 			setupTimeChangeListener();
 		}
 		const video = $('video');
@@ -42,7 +42,7 @@ module.exports = () => {
 
 		function sendSongInfo() {
 			const data = apiEvent.detail.getPlayerResponse();
-      data.videoDetails.album = $('ytmusic-player-page')?.__data?.playerPageWatchMetadata?.albumName?.runs[0].text
+			data.videoDetails.album = $('ytmusic-player-page')?.__data?.playerPageWatchMetadata?.albumName?.runs[0].text
 			data.videoDetails.elapsedSeconds = Math.floor(video.currentTime);
 			data.videoDetails.isPaused = false;
 			ipcRenderer.send("video-src-changed", JSON.stringify(data));

--- a/providers/song-info-front.js
+++ b/providers/song-info-front.js
@@ -11,9 +11,19 @@ ipcRenderer.on("update-song-info", async (_, extractedSongInfo) => {
 
 module.exports = () => {
 	document.addEventListener('apiLoaded', e => {
+		setupTimeChangeListener();
+
 		document.querySelector('video').addEventListener('loadedmetadata', () => {
 			const data = e.detail.getPlayerResponse();
 			ipcRenderer.send("song-info-request", JSON.stringify(data));
 		});
 	}, { once: true, passive: true })
 };
+
+function setupTimeChangeListener() {
+	const progressObserver = new MutationObserver(mutations => {
+		ipcRenderer.send('timeChanged', mutations[0].target.value);
+		global.songInfo.elapsedSeconds = mutations[0].target.value;
+	});
+	progressObserver.observe(document.querySelector('#progress-bar'), { attributeFilter: ["value"] })
+}

--- a/providers/song-info-front.js
+++ b/providers/song-info-front.js
@@ -2,6 +2,8 @@ const { ipcRenderer } = require("electron");
 
 const { getImage } = require("./song-info");
 
+const config = require("../config");
+
 global.songInfo = {};
 
 function $(selector) { return document.querySelector(selector); }
@@ -13,7 +15,9 @@ ipcRenderer.on("update-song-info", async (_, extractedSongInfo) => {
 
 module.exports = () => {
 	document.addEventListener('apiLoaded', e => {
-		setupTimeChangeListener();
+		if (config.plugins.isEnabled('tuna-obs')) {
+			setupTimeChangeListener();
+		}
 
 		$('video').addEventListener('loadedmetadata', () => {
 			const data = e.detail.getPlayerResponse();

--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -58,7 +58,7 @@ const handleData = async (responseText, win) => {
 		songInfo.elapsedSeconds = videoDetails.elapsedSeconds;
 		songInfo.isPaused = videoDetails.isPaused;
 		songInfo.videoId = videoDetails.videoId;
-    songInfo.album = data?.videoDetails?.album
+		songInfo.album = data?.videoDetails?.album; // Will be undefined if video exist
 
 		const oldUrl = songInfo.imageSrc;
 		songInfo.imageSrc = videoDetails.thumbnail?.thumbnails?.pop()?.url.split("?")[0];

--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -45,6 +45,7 @@ const songInfo = {
 	songDuration: 0,
 	elapsedSeconds: 0,
 	url: "",
+	album: undefined
 };
 
 const handleData = async (responseText, win) => {
@@ -57,6 +58,7 @@ const handleData = async (responseText, win) => {
 	songInfo.image = await getImage(songInfo.imageSrc);
 	songInfo.uploadDate = data?.microformat?.microformatDataRenderer?.uploadDate;
 	songInfo.url = data?.microformat?.microformatDataRenderer?.urlCanonical?.split("&")[0];
+	songInfo.album = data?.videoDetails?.album
 
 	// used for options.resumeOnStart
 	config.set("url", data?.microformat?.microformatDataRenderer?.urlCanonical);

--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -45,6 +45,7 @@ const songInfo = {
 	songDuration: 0,
 	elapsedSeconds: 0,
 	url: "",
+	videoId: "",
 };
 
 const handleData = async (responseText, win) => {
@@ -57,6 +58,7 @@ const handleData = async (responseText, win) => {
 	songInfo.image = await getImage(songInfo.imageSrc);
 	songInfo.uploadDate = data?.microformat?.microformatDataRenderer?.uploadDate;
 	songInfo.url = data?.microformat?.microformatDataRenderer?.urlCanonical?.split("&")[0];
+	songInfo.videoId = data?.videoDetails?.videoId;
 
 	// used for options.resumeOnStart
 	config.set("url", data?.microformat?.microformatDataRenderer?.urlCanonical);

--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -45,7 +45,6 @@ const songInfo = {
 	songDuration: 0,
 	elapsedSeconds: 0,
 	url: "",
-	videoId: "",
 };
 
 const handleData = async (responseText, win) => {
@@ -58,7 +57,6 @@ const handleData = async (responseText, win) => {
 	songInfo.image = await getImage(songInfo.imageSrc);
 	songInfo.uploadDate = data?.microformat?.microformatDataRenderer?.uploadDate;
 	songInfo.url = data?.microformat?.microformatDataRenderer?.urlCanonical?.split("&")[0];
-	songInfo.videoId = data?.videoDetails?.videoId;
 
 	// used for options.resumeOnStart
 	config.set("url", data?.microformat?.microformatDataRenderer?.urlCanonical);


### PR DESCRIPTION
I've been testing on discord with @JoeJoeTV (many thanks for all the hours invested 😃 ) and we managed to fix all mpris issues (play/pause not working + update progress attribute + seek *from* mpris + seek *to* mpris)
should close #372

original comment with mpris bugs: https://github.com/th-ch/youtube-music/issues/65#issuecomment-964235549

> docs:
https://www.npmjs.com/package/mpris-service
https://github.com/dbusjs/mpris-service/blob/master/src/index.js#L26-L132
https://github.com/dbusjs/mpris-service/search?q=seeked
https://github.com/dbusjs/mpris-service/blob/master/examples/player.js

For obs-tuna this implements a live update to the progress

also fix #487 by changing status from `Playing`/`Paused` to `playing`/`stopped` 

this pr also adds a songInfo.album for both mpris and tuna (when available, never is available if current song has a video)

> ps. mpris could maybe be moved to its own plugin instead of 'camping' inside the shortcuts plugin