### PR TITLE
fix interaction between blur navbar & in-app-menu

### DIFF
--- a/plugins/blur-nav-bar/style.css
+++ b/plugins/blur-nav-bar/style.css
@@ -1,6 +1,6 @@
 #nav-bar-background, #header.ytmusic-item-section-renderer {
     background: rgba(0, 0, 0, 0.3) !important;
-    backdrop-filter: blur(18px) !important;
+    backdrop-filter: blur(8px) !important;
 }
 
 #nav-bar-divider {

--- a/plugins/blur-nav-bar/style.css
+++ b/plugins/blur-nav-bar/style.css
@@ -1,8 +1,10 @@
-#nav-bar-background, #header.ytmusic-item-section-renderer {
-    background: rgba(0, 0, 0, 0.3) !important;
-    backdrop-filter: blur(8px) !important;
+#nav-bar-background,
+#header.ytmusic-item-section-renderer,
+ytmusic-tabs {
+	background: rgba(0, 0, 0, 0.3) !important;
+	backdrop-filter: blur(8px) !important;
 }
 
 #nav-bar-divider {
-    display: none !important;
+	display: none !important;
 }

--- a/plugins/in-app-menu/style.css
+++ b/plugins/in-app-menu/style.css
@@ -4,7 +4,7 @@
 	font-size: 14px !important;
 }
 
-/* fixes nav-bar-background opacity bug and allows clicking scrollbar through it */
+/* fixes nav-bar-background opacity bug, reposition it, and allows clicking scrollbar through it */
 #nav-bar-background {
 	opacity: 1 !important;
 	pointer-events: none !important;
@@ -20,9 +20,10 @@ ytmusic-pivot-bar-item-renderer {
 	-webkit-app-region: unset !important;
 }
 
-/* move up item selection renderer by 13 px */
-ytmusic-item-section-renderer.stuck #header.ytmusic-item-section-renderer {
-	top: calc(var(--ytmusic-nav-bar-height) - 13px) !important;
+/* move up item selection renderers */
+ytmusic-item-section-renderer.stuck #header.ytmusic-item-section-renderer,
+ytmusic-tabs.stuck {
+	top: calc(var(--ytmusic-nav-bar-height) - 15px) !important;
 }
 
 /* fix weird positioning in search screen*/

--- a/plugins/in-app-menu/style.css
+++ b/plugins/in-app-menu/style.css
@@ -7,7 +7,10 @@
 /* fixes nav-bar-background opacity bug and allows clicking scrollbar through it */
 #nav-bar-background {
 	opacity: 1 !important;
-	pointer-events: none;
+	pointer-events: none !important;
+	position: sticky !important;
+	top: 0 !important;
+	height: 75px !important;
 }
 
 /* remove window dragging for nav bar (conflict with titlebar drag) */
@@ -19,7 +22,7 @@ ytmusic-pivot-bar-item-renderer {
 
 /* move up item selection renderer by 13 px */
 ytmusic-item-section-renderer.stuck #header.ytmusic-item-section-renderer {
-    top: calc(var(--ytmusic-nav-bar-height) - 13px) !important;
+	top: calc(var(--ytmusic-nav-bar-height) - 13px) !important;
 }
 
 /* fix weird positioning in search screen*/
@@ -28,8 +31,7 @@ ytmusic-header-renderer.ytmusic-search-page {
 }
 
 /* Move navBar downwards */
-ytmusic-nav-bar[slot="nav-bar"],
-#nav-bar-background {
+ytmusic-nav-bar[slot="nav-bar"] {
 	top: 17px !important;
 }
 


### PR DESCRIPTION
fix #490 by making the nav bar background sticky and moving it upwards which fixes the blur issues

(18px blur is now way too much, 8px is close but a bit lower than it was before - but I think it looks ok?)

this pr also fix the height of the search page item header when stuck (for in-app-menu) and include it in the blur plugin for consistency since it sticks to the navbar when scrolling down

<details>
  <summary>Click to see screenshots comparisons</summary>
  
 * Blur Before:
![Blur_Before](https://user-images.githubusercontent.com/78568641/141696986-0336b610-bfbe-476c-bb5b-a42ed5bf04c8.png)

* Blur After:
![Blur_After](https://user-images.githubusercontent.com/78568641/141697126-31bc4f7a-8731-40c5-8134-324e807e7f8f.png)

* Search page clip+blur before:
![Search-Page_Before](https://user-images.githubusercontent.com/78568641/141697204-683bfc90-9986-4501-bfd3-0cf2f9e01e83.png)

* Search page after:
![Search-Page_After](https://user-images.githubusercontent.com/78568641/141697215-e2181916-a684-4663-8cdd-3538b685dcc3.png)

</details>
