### PR TITLE
Fix mpris bugs - follows #480

### DIFF
--- a/plugins/shortcuts/mpris.js
+++ b/plugins/shortcuts/mpris.js
@@ -1,6 +1,7 @@
 const mpris = require("mpris-service");
 const { ipcMain } = require("electron");
 const registerCallback = require("../../providers/song-info");
+const getSongControls = require("../../providers/song-controls");
 
 function setupMPRIS() {
 	const player = mpris({
@@ -17,6 +18,8 @@ function setupMPRIS() {
 }
 
 function registerMPRIS(win) {
+	const songControls = getSongControls(win);
+	const { playPause, next, previous } = songControls;
 	try {
 		const secToMicro = n => Math.round(Number(n) * 1e6);
 		const microToSec = n => Math.round(Number(n) / 1e6);
@@ -26,9 +29,7 @@ function registerMPRIS(win) {
 
 		const player = setupMPRIS();
 
-		const mprisSeek = player.seeked;
-
-		ipcMain.on('seeked', (_, t) => mprisSeek(secToMicro(t)));
+		ipcMain.on('seeked', (_, t) => player.seeked(secToMicro(t)));
 
 		let currentSeconds = 0;
 		ipcMain.on('timeChanged', (_, t) => currentSeconds = t);
@@ -71,7 +72,7 @@ function registerMPRIS(win) {
 				};
 				if (songInfo.album) data['xesam:album'] = songInfo.album;
 				player.metadata = data;
-				mprisSeek(secToMicro(songInfo.elapsedSeconds))
+				player.seeked(secToMicro(songInfo.elapsedSeconds))
 				player.playbackStatus = songInfo.isPaused ? "Paused" : "Playing"
 			}
 		})

--- a/providers/song-controls-front.js
+++ b/providers/song-controls-front.js
@@ -4,12 +4,10 @@ const is = require("electron-is");
 
 module.exports.setupSongControls = () => {
     document.addEventListener('apiLoaded', e => {
-        ipcRenderer.on("seekTo", (_, t) => e.target.seekTo(t));
-        ipcRenderer.on("seekBy", (_, t) => e.target.seekBy(t));
-
+        ipcRenderer.on("seekTo", (_, t) => e.detail.seekTo(t));
+        ipcRenderer.on("seekBy", (_, t) => e.detail.seekBy(t));
+        if (is.linux() && config.plugins.isEnabled('shortcuts')) { // MPRIS Enabled
+            document.querySelector('video').addEventListener('seeked', v => ipcRenderer.send('seeked', v.target.currentTime));
+        }
     }, { once: true, passive: true })
-
-    if (is.linux() && config.plugins.isEnabled('shortcuts')) { // MPRIS Enabled
-        document.querySelector('video').addEventListener('seeked', () => ipcRenderer.send('seeked', v.currentTime));
-    }
 };

--- a/providers/song-info-front.js
+++ b/providers/song-info-front.js
@@ -1,5 +1,5 @@
 const { ipcRenderer } = require("electron");
-
+const is = require('electron-is');
 const { getImage } = require("./song-info");
 
 const config = require("../config");
@@ -18,7 +18,8 @@ const srcChangedEvent = new CustomEvent('srcChanged');
 
 module.exports = () => {
 	document.addEventListener('apiLoaded', apiEvent => {
-		if (config.plugins.isEnabled('tuna-obs')) {
+		if (config.plugins.isEnabled('tuna-obs') ||
+			(is.linux() && config.plugins.isEnabled('shortcuts'))) {
 			setupTimeChangeListener();
 		}
 		const video = $('video');

--- a/youtube-music.css
+++ b/youtube-music.css
@@ -34,3 +34,8 @@ img {
 	-webkit-user-select: none;
 	user-select: none;
 }
+
+/* Hide cast button which doesn't work */
+ytmusic-cast-button {
+	display: none !important;
+}


### PR DESCRIPTION
I sadly couldn't test the changes on linux after the latest merge conflict solving on PR #480 since I use windows, and some stupid bugs made their way to the main branch because of that.

Thankfully @JoeJoeTV helped test mpris on linux once again, and all the little bugs have been fixed in this PR

Sorry about those!

-fix missing songControls (forgot to re-add it after moving the code from `shortcuts/back.js` to `shortcuts/mpris.js` 🤦🏼‍♂️)
-fix e.target instead of e.detail in apiLoaded event (to access the api)
-fix document.querySelector('video') being called before apiLoaded
-fix 'seeked' event listener
-setup timeChange Listener if on linux+shortcuts enabled

(I also added a sneaky change to the youtube-music.css that hides the chromecast button which doesn't work because electron doesn't support[[1](https://github.com/electron/electron/issues/869)][[2](https://github.com/electron/electron/issues/7024)] the `chrome.cast` api)