### PR TITLE
fixes mpris bug in snap

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
 				"deb",
 				"rpm"
 			]
+		},
+		"snap": {
+			"slots": [{ "mpris": { "interface": "mpris" }}]
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
Seems that to make mpris work properly in snap, we need to add the slot.