### PR TITLE
Add album art/thumbnail to discord activity

### DIFF
--- a/plugins/discord/back.js
+++ b/plugins/discord/back.js
@@ -103,7 +103,7 @@ module.exports = (win, { activityTimoutEnabled, activityTimoutTime, listenAlong 
 			type: 2, // Listening, addressed in https://github.com/discordjs/RPC/pull/149
 			details: songInfo.title,
 			state: songInfo.artist,
-			largeImageKey: "logo",
+			largeImageKey: songInfo.imageSrc,
 			largeImageText: [
 				songInfo.uploadDate,
 				songInfo.views.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") + " views",


### PR DESCRIPTION
Proof of feature:

https://twitter.com/PreMiDapp/status/1474069707003252739
![image](https://user-images.githubusercontent.com/12068027/147279906-f9aa4714-e08f-466d-bdfb-4f31b47d9605.png)
![image](https://user-images.githubusercontent.com/12068027/147279961-8d796bb0-2d34-433d-a811-3c23f07dfef9.png)
![image](https://user-images.githubusercontent.com/12068027/147280111-4b63bcd5-2d5d-4e15-af1d-ba2a8bfbcfdd.png)
`mp:external/cRJruHj4qNHp3LwdwWyU-G6F-zpLV7c9Hx43YBbfr6k/%3Fsqp%3D-oaymwEWCJADEOEBIAQqCghqEJQEGHgg6AJIWg%26rs%3DAMzJL3m93pBxkZxggOYiujabXNtTjic5kw/https/i.ytimg.com/vi/wKhRnZZ0cJI/sddefault.jpg`
https://github.com/PreMiD/Presences/blob/main/websites/Y/YouTube%20Music/presence.ts#L79

This is currently undocumented in discord docs, but it is a working feature already rolled out through PreMiD to thousands.