### PR TITLE
fix precise-volume options sync

### DIFF
--- a/plugins/precise-volume/front.js
+++ b/plugins/precise-volume/front.js
@@ -34,6 +34,14 @@ function firstRun(options) {
 	if (!noVid) {
 		setupVideoPlayerOnwheel(options);
 	}
+
+	// Change options from renderer to keep sync
+	ipcRenderer.on("setOptions", (_event, newOptions = {}) => {
+		for (option in newOptions) {
+			options[option] = newOptions[option];
+		}
+		setOptions("precise-volume", options);
+	});
 }
 
 function injectVolumeHud(noVid) {
@@ -93,7 +101,7 @@ function writeOptions(options) {
 	writeTimeout = setTimeout(() => {
 		setOptions("precise-volume", options);
 		writeTimeout = null;
-	}, 1500)
+	}, 1000)
 }
 
 /** Add onwheel event to play bar and also track if play bar is hovered*/
@@ -142,7 +150,7 @@ function setupSliderObserver(options) {
 /** if (toIncrease = false) then volume decrease */
 function changeVolume(toIncrease, options) {
 	// Apply volume change if valid
-	const steps = (options.steps || 1);
+	const steps = Number(options.steps || 1);
 	api.setVolume(toIncrease ?
 		Math.min(api.getVolume() + steps, 100) :
 		Math.max(api.getVolume() - steps, 0));
@@ -211,39 +219,17 @@ function setupGlobalShortcuts(options) {
 
 function setupLocalArrowShortcuts(options) {
 	if (options.arrowsShortcut) {
-		addListener();
-	}
-
-	// Change options from renderer to keep sync
-	ipcRenderer.on("setArrowsShortcut", (_event, isEnabled) => {
-		options.arrowsShortcut = isEnabled;
-		setOptions("precise-volume", options);
-		// This allows changing this setting without restarting app
-		if (isEnabled) {
-			addListener();
-		} else {
-			removeListener();
-		}
-	});
-
-	function addListener() {
-		window.addEventListener('keydown', callback);
-	}
-
-	function removeListener() {
-		window.removeEventListener("keydown", callback);
-	}
-
-	function callback(event) {
-		switch (event.code) {
-			case "ArrowUp":
-				event.preventDefault();
-				changeVolume(true, options);
-				break;
-			case "ArrowDown":
-				event.preventDefault();
-				changeVolume(false, options);
-				break;
-		}
+		window.addEventListener('keydown', (event) => {
+			switch (event.code) {
+				case "ArrowUp":
+					event.preventDefault();
+					changeVolume(true, options);
+					break;
+				case "ArrowDown":
+					event.preventDefault();
+					changeVolume(false, options);
+					break;
+			}
+		});
 	}
 }


### PR DESCRIPTION
As title says, this PR mainly aims to fix an issue with precise-volume options sync between main and renderer
(for example changing keybinds (menu.js) and then changing the volume (front.js) would reset the keybind)

those 2 fixes below are also included:
* fixed an issue where the custom volume steps was interpreted as a string instead of a number
* slightly reduced the "cooldown" for saving the volume