### PR TITLE
fix notifications showing thumbnail of last song

### DIFF
--- a/providers/song-info.js
+++ b/providers/song-info.js
@@ -86,10 +86,14 @@ const registerCallback = (callback) => {
 	callbacks.push(callback);
 };
 
+let handlingData = false;
+
 const registerProvider = (win) => {
 	// This will be called when the song-info-front finds a new request with song data
 	ipcMain.on("video-src-changed", async (_, responseText) => {
+		handlingData = true;
 		await handleData(responseText, win);
+		handlingData = false;
 		callbacks.forEach((c) => {
 			c(songInfo);
 		});
@@ -97,6 +101,7 @@ const registerProvider = (win) => {
 	ipcMain.on("playPaused", (_, { isPaused, elapsedSeconds }) => {
 		songInfo.isPaused = isPaused;
 		songInfo.elapsedSeconds = elapsedSeconds;
+		if (handlingData) return;
 		callbacks.forEach((c) => {
 			c(songInfo);
 		});


### PR DESCRIPTION
because of the delay in `await getImage()` in songInfo.js, if the video sends a pause/play event before `getImage()` finishes, it will send callbacks with the new songInfo - but with the old songInfo.image + everything that comes after that `await` in the code 

and thats because `handleData()` function updates *some* of the songInfo, then tries to download the image which takes a few miliseconds. so if the callbacks from playPause are triggered meanwhile, it will have new data from before the `await getImage()` but not the rest since it wasn't updated yet.

I hope this explanation was clear enough. if not then I can try explaining more clearly