### PR TITLE
xesam:artist should be a list

### DIFF
--- a/plugins/shortcuts/mpris.js
+++ b/plugins/shortcuts/mpris.js
@@ -67,7 +67,7 @@ function registerMPRIS(win) {
 					'mpris:length': secToMicro(songInfo.songDuration),
 					'mpris:artUrl': songInfo.imageSrc,
 					'xesam:title': songInfo.title,
-					'xesam:artist': songInfo.artist,
+					'xesam:artist': [songInfo.artist],
 					'mpris:trackid': '/'
 				};
 				if (songInfo.album) data['xesam:album'] = songInfo.album;


### PR DESCRIPTION
According to mpris specs artists should be a list of strings:

https://www.freedesktop.org/wiki/Specifications/mpris-spec/metadata/#xesam:artist

Thus this was not working in gnome-shell :(