### PR TITLE
fix app starting offscreen

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,12 +122,16 @@ function createMainWindow() {
 		autoHideMenuBar: config.get("options.hideMenu"),
 	});
 	remote.enable(win.webContents);
+
 	if (windowPosition) {
 		const { x, y } = windowPosition;
-		if(x + win.getSize()[0] < 0 || x - win.getSize()[0] > electron.screen.getDisplayNearestPoint({x, y}).bounds.width) {
+		const winSize = win.getSize();
+		const displaySize = electron.screen.getDisplayNearestPoint(windowPosition).bounds;
+		if((x + winSize[0] < 0 || x -winSize[0] > displaySize.width) ||
+		   (y < 0 || y > displaySize.height)) {
 			//Window is offscreen
 			if (is.dev()) {
-				console.log(`Window tried to render offscreen, Width=${win.getSize()[0]}, nearestDisplayPointer.bounds=${electron.screen.getDisplayNearestPoint({x, y}).bounds}, position=${{x, y}}`);
+				console.log(`Window tried to render offscreen, windowSize=${winSize}, displaySize=${displaySize}, position=${windowPosition}`);
 			}
 		} else { 
 			win.setPosition(x, y);

--- a/index.js
+++ b/index.js
@@ -127,8 +127,8 @@ function createMainWindow() {
 		const { x, y } = windowPosition;
 		const winSize = win.getSize();
 		const displaySize = electron.screen.getDisplayNearestPoint(windowPosition).bounds;
-		if((x + winSize[0] < -8 || x - winSize[0] > displaySize.width) ||
-		   (y < -8 || y > displaySize.height)) {
+		if((x + winSize[0] < displaySize.x - 8 || x - winSize[0] > displaySize.x + displaySize.width) ||
+		   (y < displaySize.y - 8 || y > displaySize.y + displaySize.height)) {
 			//Window is offscreen
 			if (is.dev()) {
 				console.log(`Window tried to render offscreen, windowSize=${winSize}, displaySize=${displaySize}, position=${windowPosition}`);

--- a/index.js
+++ b/index.js
@@ -124,7 +124,14 @@ function createMainWindow() {
 	remote.enable(win.webContents);
 	if (windowPosition) {
 		const { x, y } = windowPosition;
-		win.setPosition(x, y);
+		if(x + win.getSize()[0] < 0 || x - win.getSize()[0] > electron.screen.getDisplayNearestPoint({x, y}).bounds.width) {
+			//Window is offscreen
+			if (is.dev()) {
+				console.log(`Window tried to render offscreen, Width=${win.getSize()[0]}, nearestDisplayPointer.bounds=${electron.screen.getDisplayNearestPoint({x, y}).bounds}, position=${{x, y}}`);
+			}
+		} else { 
+			win.setPosition(x, y);
+		}
 	}
 	if (windowMaximized) {
 		win.maximize();

--- a/index.js
+++ b/index.js
@@ -127,8 +127,8 @@ function createMainWindow() {
 		const { x, y } = windowPosition;
 		const winSize = win.getSize();
 		const displaySize = electron.screen.getDisplayNearestPoint(windowPosition).bounds;
-		if((x + winSize[0] < 0 || x -winSize[0] > displaySize.width) ||
-		   (y < 0 || y > displaySize.height)) {
+		if((x + winSize[0] < -8 || x - winSize[0] > displaySize.width) ||
+		   (y < -8 || y > displaySize.height)) {
 			//Window is offscreen
 			if (is.dev()) {
 				console.log(`Window tried to render offscreen, windowSize=${winSize}, displaySize=${displaySize}, position=${windowPosition}`);


### PR DESCRIPTION
Aims to fix issues such as #193 #542, probably fix #517

checks if the app is completely offscreen (x / width) or if the titlebar is offscreen (y / height) 
> checks if window is inside the display closest to the given point

**Tested on multiple monitor setup and works perfectly**