### PR TITLE
allow downloading playlists from popup menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
 		"mpris-service": "^2.1.2",
 		"node-fetch": "^2.6.6",
 		"node-notifier": "^9.0.1",
-		"ytdl-core": "^4.9.2",
+		"ytdl-core": "^4.10.0",
 		"ytpl": "^2.2.3"
 	},
 	"devDependencies": {

--- a/plugins/downloader/front.js
+++ b/plugins/downloader/front.js
@@ -1,4 +1,4 @@
-const { contextBridge } = require("electron");
+const { ipcRenderer } = require("electron");
 
 const { defaultConfig } = require("../../config");
 const { getSongMenu } = require("../../providers/dom-elements");
@@ -13,15 +13,17 @@ const downloadButton = ElementFromFile(
 );
 let pluginOptions = {};
 
-const observer = new MutationObserver((mutations, observer) => {
+const observer = new MutationObserver(() => {
 	if (!menu) {
 		menu = getSongMenu();
+		if (!menu) return;
 	}
+	if (menu.contains(downloadButton)) return;
+	const menuUrl = document.querySelector('tp-yt-paper-listbox [tabindex="0"] #navigation-endpoint')?.href;
+	if (menuUrl && !menuUrl.includes('watch?')) return;
 
-	if (menu && !menu.contains(downloadButton)) {
-		menu.prepend(downloadButton);
-		progress = document.querySelector("#ytmcustom-download");
-	}
+	menu.prepend(downloadButton);
+	progress = document.querySelector("#ytmcustom-download");
 });
 
 const reinit = () => {
@@ -46,7 +48,13 @@ global.download = () => {
 		?.querySelector('ytmusic-menu-navigation-item-renderer.iron-selected[tabindex="0"] #navigation-endpoint')
 		?.getAttribute("href");
 	if (videoUrl) {
-		videoUrl = baseUrl + "/" + videoUrl;
+		if (videoUrl.startsWith('watch?')) {
+			videoUrl = baseUrl + "/" + videoUrl;
+		}
+		if (videoUrl.includes('?playlist=')) {
+			ipcRenderer.send('download-playlist-request', videoUrl);
+			return;
+		}
 		metadata = null;
 	} else {
 		metadata = global.songInfo;
@@ -78,10 +86,13 @@ global.download = () => {
 
 function observeMenu(options) {
 	pluginOptions = { ...pluginOptions, ...options };
-	observer.observe(document, {
-		childList: true,
-		subtree: true,
-	});
+
+	document.addEventListener('apiLoaded', () => {
+		observer.observe(document.querySelector('ytmusic-popup-container'), {
+			childList: true,
+			subtree: true,
+		});
+	}, { once: true, passive: true })
 }
 
 module.exports = observeMenu;

--- a/plugins/downloader/front.js
+++ b/plugins/downloader/front.js
@@ -45,7 +45,7 @@ global.download = () => {
 	let metadata;
 	let videoUrl = getSongMenu()
 		// selector of first button which is always "Start Radio"
-		?.querySelector('ytmusic-menu-navigation-item-renderer.iron-selected[tabindex="0"] #navigation-endpoint')
+		?.querySelector('ytmusic-menu-navigation-item-renderer[tabindex="0"] #navigation-endpoint')
 		?.getAttribute("href");
 	if (videoUrl) {
 		if (videoUrl.startsWith('watch?')) {

--- a/plugins/downloader/menu.js
+++ b/plugins/downloader/menu.js
@@ -14,87 +14,21 @@ let downloadLabel = defaultMenuDownloadLabel;
 let playingPlaylistId = undefined;
 let callbackIsRegistered = false;
 
+const INVALID_PLAYLIST_MODIFIER = 'RDAMPLPL';
+
 module.exports = (win, options) => {
 	if (!callbackIsRegistered) {
 		ipcMain.on("video-src-changed", async (_, data) => {
 			playingPlaylistId = JSON.parse(data)?.videoDetails?.playlistId;
 		});
+		ipcMain.on("download-playlist-request", async (_event, url) => downloadPlaylist(url, win, options));
 		callbackIsRegistered = true;
 	}
 
 	return [
 		{
 			label: downloadLabel,
-			click: async () => {
-				const currentPagePlaylistId = new URL(win.webContents.getURL()).searchParams.get("list");
-				const playlistId = currentPagePlaylistId || playingPlaylistId;
-				if (!playlistId) {
-					sendError(win, new Error("No playlist ID found"));
-					return;
-				}
-
-				console.log(`trying to get playlist ID: '${playlistId}'`);
-				let playlist;
-				try {
-					playlist = await ytpl(playlistId, {
-						limit: options.playlistMaxItems || Infinity,
-					});
-				} catch (e) {
-					sendError(win, e);
-					return;
-				}
-				const playlistTitle = playlist.title;
-
-				const folder = getFolder(options.downloadFolder);
-				const playlistFolder = join(folder, playlistTitle);
-				if (existsSync(playlistFolder)) {
-					sendError(
-						win,
-						new Error(`The folder ${playlistFolder} already exists`)
-					);
-					return;
-				}
-				mkdirSync(playlistFolder, { recursive: true });
-
-				dialog.showMessageBox({
-					type: "info",
-					buttons: ["OK"],
-					title: "Started Download",
-					message: `Downloading Playlist "${playlistTitle}"`,
-					detail: `(${playlist.items.length} songs)`,
-				});
-
-				if (is.dev()) {
-					console.log(
-						`Downloading playlist "${playlistTitle}" (${playlist.items.length} songs)`
-					);
-				}
-
-				const steps = 1 / playlist.items.length;
-				let progress = 0;
-
-				win.setProgressBar(2); // starts with indefinite bar
-
-				let dirWatcher = chokidar.watch(playlistFolder);
-				dirWatcher.on('add', () => {
-					progress += steps;
-					if (progress >= 0.9999) {
-						win.setProgressBar(-1); // close progress bar
-						dirWatcher.close().then(() => dirWatcher = null);
-					} else {
-						win.setProgressBar(progress);
-					}
-				});
-
-				playlist.items.forEach((song) => {
-					win.webContents.send(
-						"downloader-download-playlist",
-						song.url,
-						playlistTitle,
-						options
-					);
-				});
-			},
+			click: () => downloadPlaylist(undefined, win, options)
 		},
 		{
 			label: "Choose download folder",
@@ -123,3 +57,87 @@ module.exports = (win, options) => {
 		},
 	];
 };
+
+async function downloadPlaylist(url, win, options) {
+	const getPlaylistID = aURL => {
+		const result = aURL?.searchParams.get("list") || aURL?.searchParams.get("playlist");
+		return (!result || result.startsWith(INVALID_PLAYLIST_MODIFIER)) ? undefined : result;
+	};
+	if (url) {
+		try {
+			url = new URL(url);
+		} catch {
+			url = undefined;
+		};
+	}
+	const playlistId = getPlaylistID(url)
+		|| getPlaylistID(new URL(win.webContents.getURL()))
+		|| playingPlaylistId;
+
+	if (!playlistId) {
+		sendError(win, new Error("No playlist ID found"));
+		return;
+	}
+
+	console.log(`trying to get playlist ID: '${playlistId}'`);
+	let playlist;
+	try {
+		playlist = await ytpl(playlistId, {
+			limit: options.playlistMaxItems || Infinity,
+		});
+	} catch (e) {
+		sendError(win, e);
+		return;
+	}
+	const playlistTitle = playlist.title;
+
+	const folder = getFolder(options.downloadFolder);
+	const playlistFolder = join(folder, playlistTitle);
+	if (existsSync(playlistFolder)) {
+		sendError(
+			win,
+			new Error(`The folder ${playlistFolder} already exists`)
+		);
+		return;
+	}
+	mkdirSync(playlistFolder, { recursive: true });
+
+	dialog.showMessageBox({
+		type: "info",
+		buttons: ["OK"],
+		title: "Started Download",
+		message: `Downloading Playlist "${playlistTitle}"`,
+		detail: `(${playlist.items.length} songs)`,
+	});
+
+	if (is.dev()) {
+		console.log(
+			`Downloading playlist "${playlistTitle}" - ${playlist.items.length} songs (${playlistId})`
+		);
+	}
+
+	const steps = 1 / playlist.items.length;
+	let progress = 0;
+
+	win.setProgressBar(2); // starts with indefinite bar
+
+	let dirWatcher = chokidar.watch(playlistFolder);
+	dirWatcher.on('add', () => {
+		progress += steps;
+		if (progress >= 0.9999) {
+			win.setProgressBar(-1); // close progress bar
+			dirWatcher.close().then(() => dirWatcher = null);
+		} else {
+			win.setProgressBar(progress);
+		}
+	});
+
+	playlist.items.forEach((song) => {
+		win.webContents.send(
+			"downloader-download-playlist",
+			song.url,
+			playlistTitle,
+			options
+		);
+	});
+}

--- a/plugins/downloader/youtube-dl.js
+++ b/plugins/downloader/youtube-dl.js
@@ -46,7 +46,7 @@ const downloadVideoToMP3 = async (
 				cleanupName(videoDetails?.author?.name) ||
 				"",
 			title: videoDetails?.media?.song || videoDetails?.title || "",
-			imageSrcYTPL: thumbnails ? 
+			imageSrcYTPL: thumbnails ?
 				urlToJPG(thumbnails[thumbnails.length - 1].url, videoDetails?.videoId)
 				: ""
 		}

--- a/plugins/playback-speed/front.js
+++ b/plugins/playback-speed/front.js
@@ -30,7 +30,7 @@ const observePopupContainer = () => {
 			menu = getSongMenu();
 		}
 
-		if (menu && !menu.contains(slider)) {
+		if (menu && menu.lastElementChild.lastElementChild.innerText.startsWith('Stats') && !menu.contains(slider)) {
 			menu.prepend(slider);
 			if (!observingSlider) {
 				setupSliderListener();

--- a/yarn.lock
+++ b/yarn.lock
@@ -8361,10 +8361,10 @@ yocto-queue@^1.0.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
-ytdl-core@^4.9.2:
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/ytdl-core/-/ytdl-core-4.9.2.tgz#c2d1ec44ee3cabff35e5843c6831755e69ffacf0"
-  integrity sha512-aTlsvsN++03MuOtyVD4DRF9Z/9UAeeuiNbjs+LjQBAiw4Hrdp48T3U9vAmRPyvREzupraY8pqRoBfKGqpq+eHA==
+ytdl-core@^4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/ytdl-core/-/ytdl-core-4.10.0.tgz#0835cb411677684539fac2bcc10553f6f58db3e1"
+  integrity sha512-RCCoSVTmMeBPH5NFR1fh3nkDU9okvWM0ZdN6plw6I5+vBBZVUEpOt8vjbSgprLRMmGUsmrQZJhvG1CHOat4mLA==
   dependencies:
     m3u8stream "^0.8.4"
     miniget "^4.0.0"


### PR DESCRIPTION
:nazar_amulet: fix #516 , fix #432, fix #190

Allows downloading playlist from the popup menu (previously the button was shown buy didn't work as intended)

The following is the basic way it works:
```js
global.download = () => { 
    let videoUrl = getSongMenu().....href
    ...
    if (videoUrl.includes('?playlist=')) {
		ipcRenderer.send('download-playlist-request', videoUrl);
		return;
	}
]
```

it also removes the button when the popup menu is opened from an artist page header's (since there is nothing to download)
https://github.com/th-ch/youtube-music/blob/21c149efc7b4432e111f503e225d92ca88d29262/plugins/downloader/front.js#L23-L25

> Note: `INVALID_PLAYLIST_MODIFIER = 'RDAMPL'` is an invalid modifier that shows up when getting playlist id from the popup-menu of a **playlist page** (in that case the first button is radio and this modifier is inserted into the id)

:nazar_amulet: update ytdl-core (many improvements including **way faster download speed**), fix #492

:nazar_amulet: fix playback-speed slider showing up on popup menu's it shouldn't show in (c7e793b)


<details>
<summary><b>Screenshots of fixed playlist download buttons in the popup menu (Click to reveal)</b></summary>

> NOTE: the playback speed slider is showing up when it shouldn't in those screenshots but was also fixed afterwards in [c7e793](https://github.com/th-ch/youtube-music/pull/549/commits/c7e793b66ec734bd08b6012ac67b1435381927ec)

### in playlist page header
![image](https://user-images.githubusercontent.com/78568641/149024365-0a92b0d5-0545-41cc-96b3-89562a0caf2f.png)
### in playlist square renderer
![image](https://user-images.githubusercontent.com/78568641/149024436-7ecf36f8-0a38-438a-800f-5c264fde8aa0.png)
### in artist page
![image](https://user-images.githubusercontent.com/78568641/149024529-0c54123c-a654-464c-9c60-dbdb81916162.png)


</details>





