### PR TITLE
show a badge remaining items when downloading a playlist

### DIFF
--- a/plugins/downloader/menu.js
+++ b/plugins/downloader/menu.js
@@ -8,7 +8,7 @@ const chokidar = require('chokidar');
 
 const { setOptions } = require("../../config/plugins");
 const { sendError } = require("./back");
-const { defaultMenuDownloadLabel, getFolder, presets } = require("./utils");
+const { defaultMenuDownloadLabel, getFolder, presets, setBadge } = require("./utils");
 
 let downloadLabel = defaultMenuDownloadLabel;
 let playingPlaylistId = undefined;
@@ -70,19 +70,21 @@ module.exports = (win, options) => {
 					);
 				}
 
-				const steps = 1 / playlist.items.length;
-				let progress = 0;
-
 				win.setProgressBar(2); // starts with indefinite bar
+
+				let downloadCount = 0;
+				setBadge(playlist.items.length);
 
 				let dirWatcher = chokidar.watch(playlistFolder);
 				dirWatcher.on('add', () => {
-					progress += steps;
-					if (progress >= 0.9999) {
+					downloadCount += 1;
+					if (downloadCount >= playlist.items.length) {
 						win.setProgressBar(-1); // close progress bar
+						setBadge(0); // close badge counter
 						dirWatcher.close().then(() => dirWatcher = null);
 					} else {
-						win.setProgressBar(progress);
+						win.setProgressBar(downloadCount / playlist.items.length);
+						setBadge(playlist.items.length - downloadCount);
 					}
 				});
 

--- a/plugins/downloader/menu.js
+++ b/plugins/downloader/menu.js
@@ -77,7 +77,7 @@ module.exports = (win, options) => {
 
 				let dirWatcher = chokidar.watch(playlistFolder);
 				dirWatcher.on('add', () => {
-					downloadCount += 1;
+					downloadCount++;
 					if (downloadCount >= playlist.items.length) {
 						win.setProgressBar(-1); // close progress bar
 						setBadge(0); // close badge counter

--- a/plugins/downloader/utils.js
+++ b/plugins/downloader/utils.js
@@ -1,4 +1,5 @@
 const electron = require("electron");
+const is = require('electron-is');
 
 module.exports.getFolder = customFolder => customFolder || electron.app.getPath("downloads");
 module.exports.defaultMenuDownloadLabel = "Download playlist";
@@ -37,3 +38,9 @@ module.exports.presets = {
 		ffmpegArgs: ["-acodec", "libopus"],
 	},
 };
+
+module.exports.setBadge = num => {
+	if (is.linux() || is.macOS()) {
+		electron.app.badgeCount = num;
+	}
+}

--- a/plugins/downloader/utils.js
+++ b/plugins/downloader/utils.js
@@ -39,8 +39,8 @@ module.exports.presets = {
 	},
 };
 
-module.exports.setBadge = num => {
+module.exports.setBadge = n => {
 	if (is.linux() || is.macOS()) {
-		electron.app.badgeCount = num;
+		electron.app.setBadgeCount(n);
 	}
 }


### PR DESCRIPTION
![#](https://raw.githubusercontent.com/sindresorhus/electron-dl/main/screenshot.png) 

badge shows remaining tracks to download

only works on linux and macOS, thus I couldn't personally test this since im on windows.

can any mac/linux dev/user test and confirm it works?