### PR TITLE
Fix duplicate media session on linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,11 @@ if (config.get("options.disableHardwareAcceleration")) {
 	app.disableHardwareAcceleration();
 }
 
+if (is.linux() && config.plugins.isEnabled("shortcuts")) {
+	//stops chromium from launching it's own mpris service
+	app.commandLine.appendSwitch('disable-features', 'MediaSessionService');
+}
+
 if (config.get("options.proxy")) {
 	app.commandLine.appendSwitch("proxy-server", config.get("options.proxy"));
 }


### PR DESCRIPTION
On linux chromium shouldn't register its own mpris service if the app does it (currently bundled in the `shortcuts` plugin)

Fix #514 (the half that wasn't fixed in the last PR)

> thanks @JoeJoeTV for testing