### PR TITLE
fix window position save spam

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,7 +172,6 @@ function createMainWindow() {
 		savedTimeouts[key] = setTimeout(() => {
 			config.set(key, value);
 			savedTimeouts[key] = undefined;
-
 		}, 1000)
 	}
 

--- a/index.js
+++ b/index.js
@@ -143,20 +143,36 @@ function createMainWindow() {
 
 	win.on("move", () => {
 		let position = win.getPosition();
-		config.set("window-position", { x: position[0], y: position[1] });
+		lateSave("window-position", { x: position[0], y: position[1] });
 	});
+
+	let winWasMaximized;
 
 	win.on("resize", () => {
 		const windowSize = win.getSize();
 
-		config.set("window-maximized", win.isMaximized());
-		if (!win.isMaximized()) {
-			config.set("window-size", {
+		const isMaximized = win.isMaximized();
+		if (winWasMaximized !== isMaximized) {
+			winWasMaximized = isMaximized;
+			config.set("window-maximized", isMaximized);
+		}
+		if (!isMaximized) {
+			lateSave("window-size", {
 				width: windowSize[0],
 				height: windowSize[1],
 			});
 		}
 	});
+
+	let savedTimeouts = {};
+	function lateSave(key, value) {
+		if (savedTimeouts[key]) clearTimeout(savedTimeouts[key]);
+
+		savedTimeouts[key] = setTimeout(() => {
+			config.set(key, value);
+			savedTimeouts[key] = undefined;
+		}, 1000)
+	}
 
 	win.webContents.on("render-process-gone", (event, webContents, details) => {
 		showUnresponsiveDialog(win, details);


### PR DESCRIPTION
Previously when moving/resizing the window, the position would get spam saved to config, this PR introduce a timer (1sec) to keep it from spamming,

this also fix window position being' forgotten' on maximizing (happened because a `move` event is triggered to the top left of the screen when maximizing the window, atleast on windows)