### PR TITLE
fix precise-volume hud positioning

### DIFF
--- a/plugins/video-toggle/front.js
+++ b/plugins/video-toggle/front.js
@@ -1,6 +1,8 @@
 const { ElementFromFile, templatePath } = require("../utils");
 
-const { setOptions } = require("../../config/plugins");
+const { setOptions, isEnabled } = require("../../config/plugins");
+
+const moveVolumeHud = isEnabled("precise-volume") ? require("../precise-volume/front").moveVolumeHud : ()=>{};
 
 function $(selector) { return document.querySelector(selector); }
 
@@ -39,7 +41,7 @@ function setup(e) {
         changeDisplay(e.target.checked);
         setOptions("video-toggle", options);
     })
-  
+
     video.addEventListener('srcChanged', videoStarted);
 
     observeThumbnail();
@@ -87,13 +89,6 @@ function forcePlaybackMode() {
         });
     });
     playbackModeObserver.observe(player, { attributeFilter: ["playback-mode"] });
-}
-
-// if precise volume plugin is enabled, move its hud to be on top of the video
-function moveVolumeHud(showVideo) {
-    const volumeHud = $('#volumeHud');
-    if (volumeHud)
-        volumeHud.style.top = showVideo ? `${(player.clientHeight - video.clientHeight) / 2}px` : 0;
 }
 
 function observeThumbnail() {


### PR DESCRIPTION
This change was needed for 2 reasons:
* Video.clientHeight update delay on `srcChanged` event:
https://github.com/th-ch/youtube-music/blob/89ea66ba2b425a3a797a9429746a83532bf548b2/plugins/video-toggle/front.js#L43
the following code was supposed to position the hud, but `video.clientHeight` was 0 (because it wasn't updated yet)
https://github.com/th-ch/youtube-music/blob/89ea66ba2b425a3a797a9429746a83532bf548b2/plugins/video-toggle/front.js#L96
fixed by setting a tiny delay (250ms) before changing the hud position

----

* hud sometimes mispositioned when video-toggle is off:
the active hud positioning was only inside the video-toggle plugin, so I moved it to the precise-volume plugin.
now if video-toggle is enabled - it will handle all hud positioning, and if it isn't, then precise-volume will handle it itself