### PR TITLE
get album name from DOM

### DIFF
--- a/providers/song-info-front.js
+++ b/providers/song-info-front.js
@@ -6,7 +6,8 @@ const config = require("../config");
 
 global.songInfo = {};
 
-function $(selector) { return document.querySelector(selector); }
+const $ = s => document.querySelector(s);
+const $$ = s => Array.from(document.querySelectorAll(s));
 
 ipcRenderer.on("update-song-info", async (_, extractedSongInfo) => {
 	global.songInfo = JSON.parse(extractedSongInfo);
@@ -43,7 +44,11 @@ module.exports = () => {
 
 		function sendSongInfo() {
 			const data = apiEvent.detail.getPlayerResponse();
-			data.videoDetails.album = $('ytmusic-player-page')?.__data?.playerPageWatchMetadata?.albumName?.runs[0].text
+
+			data.videoDetails.album = $$(
+				".byline.ytmusic-player-bar > .yt-simple-endpoint"
+			).find(e => e.href?.includes("browse"))?.textContent;
+
 			data.videoDetails.elapsedSeconds = Math.floor(video.currentTime);
 			data.videoDetails.isPaused = false;
 			ipcRenderer.send("video-src-changed", JSON.stringify(data));


### PR DESCRIPTION
### Problem
`$('ytmusic-player-page').__data.playerPageWatchMetadata` isn't reliable at all

### Solution
Grabs album name from dom (available only if in "song" mode, else will be `undefined`)


* `$$(".byline.ytmusic-player-bar > .yt-simple-endpoint")` 
  gets the links in the footer which will be either [channel] for video mode or [artist, album] for song mode
![image](https://user-images.githubusercontent.com/78568641/151721478-3d04e4ed-1a48-45de-be5e-fdb6c487d457.png)


* `.find(e => e.href?.includes("browse"))`
  this should only match album links
   * artist/channel link is `https://music.youtube.com/channel/UCxxxxxxxx` 
   * album link is `https://music.youtube.com/browse/MPREb_xxxxxxx`


> grabbing straight from DOM because I can't find the album name anywhere else now