### PR TITLE
fix custom titlebar in prompt options

### DIFF
--- a/providers/prompt-options.js
+++ b/providers/prompt-options.js
@@ -1,17 +1,18 @@
 const path = require("path");
 const is = require("electron-is");
+const { isEnabled } = require("../config/plugins");
 
 const iconPath = path.join(__dirname, "..", "assets", "youtube-music-tray.png");
 const customTitlebarPath = path.join(__dirname, "prompt-custom-titlebar.js");
 
-const promptOptions = is.macOS() ? {
-    customStylesheet: "dark",
-    icon: iconPath
-} : {
+const promptOptions = !is.macOS() && isEnabled("in-app-menu") ? {
     customStylesheet: "dark",
     // The following are used for custom titlebar
     frame: false,
     customScript: customTitlebarPath,
+} : {
+    customStylesheet: "dark",
+    icon: iconPath
 };
 
 module.exports = () => promptOptions;


### PR DESCRIPTION
fix https://github.com/th-ch/youtube-music/issues/613#issuecomment-1048876106
(prompt not working on windows/linux if in-app-menu isn't enabled)

Oversight on my part, new version of `custom-electron-titlebar` requires `setupMain()` to be executed before the titlebar can be used

Fixed by enabling the custom-titlebar in prompt options only if `in-app-menu` is enabled

(macOS check is still there because i'm not sure if it works ok there)