### PR TITLE
[precise-volume] fix expand-volume-slider not updating its value

### DIFF
--- a/plugins/precise-volume/front.js
+++ b/plugins/precise-volume/front.js
@@ -189,8 +189,12 @@ function changeVolume(toIncrease, options) {
 
 function updateVolumeSlider(options) {
 	// Slider value automatically rounds to multiples of 5
-	$("#volume-slider").value = options.savedVolume > 0 && options.savedVolume < 5 ?
-		5 : options.savedVolume;
+	for (const slider of ["#volume-slider", "#expand-volume-slider"]) {
+		$(slider).value =
+			options.savedVolume > 0 && options.savedVolume < 5
+				? 5
+				: options.savedVolume;
+	}
 }
 
 let volumeHoverTimeoutID;


### PR DESCRIPTION
`#expand-volume-slider` wasn't getting updated when volume programmatically changed
fix #669

notes:
* no changes needed in `setupSliderObserver()` because manually moving the `#expand-volume-slider` automatically update the main `#volume-slider` which triggers the observer

* `showVolumeSlider()` wasn't updated because it would look weird and I see no point in automatically expanding it, 