### PR TITLE
Fix lyrics genius missing parts

### DIFF
--- a/plugins/lyrics-genius/back.js
+++ b/plugins/lyrics-genius/back.js
@@ -16,37 +16,35 @@ module.exports = async (win) => {
 			metadata.title
 		)}`;
 
-		let response = await fetch(
-			`https://genius.com/api/search/multi?per_page=5&q=${encodeURI(
-				queryString
-			)}`
-		);
-		if (!response.ok) {
-			event.returnValue = null;
-			return;
-		}
-
-		const info = await response.json();
-		let url = "";
-		try {
-			url = info.response.sections.filter(
-				(section) => section.type === "song"
-			)[0].hits[0].result.url;
-		} catch {
-			event.returnValue = null;
-			return;
-		}
-
-		if (is.dev()) {
-			console.log("Fetching lyrics from Genius:", url);
-		}
-
-		response = await fetch(url);
-		if (!response.ok) {
-			event.returnValue = null;
-			return;
-		}
-
-		event.returnValue = await response.text();
+		event.returnValue = await fetchFromGenius(queryString);
 	});
+};
+
+const fetchFromGenius = async (queryString) => {
+	let response = await fetch(
+		`https://genius.com/api/search/multi?per_page=5&q=${encodeURI(queryString)}`
+	);
+	if (!response.ok) {
+		return null;
+	}
+
+	const info = await response.json();
+	let url = "";
+	try {
+		url = info.response.sections.filter((section) => section.type === "song")[0]
+			.hits[0].result.url;
+	} catch {
+		return null;
+	}
+
+	if (is.dev()) {
+		console.log("Fetching lyrics from Genius:", url);
+	}
+
+	response = await fetch(url);
+	if (!response.ok) {
+		return null;
+	}
+
+	return await response.text();
 };

--- a/plugins/lyrics-genius/front.js
+++ b/plugins/lyrics-genius/front.js
@@ -36,15 +36,10 @@ module.exports = () => {
 
 		const wrapper = document.createElement("div");
 		wrapper.innerHTML = html;
-		const lyricsSelector1 = wrapper.querySelector(".lyrics");
-		const lyricsSelector2 = wrapper.querySelector(
-			'[class^="Lyrics__Container"]'
-		);
-		const lyrics = lyricsSelector1
-			? lyricsSelector1.innerHTML
-			: lyricsSelector2
-			? lyricsSelector2.innerHTML
-			: null;
+
+		const lyrics = Array.from(wrapper.querySelectorAll('[class^="Lyrics__Container"]')).map(d => d.innerHTML).join('<br>')
+					 || wrapper.querySelector(".lyrics")?.innerHTML;
+	
 		if (!lyrics) {
 			return;
 		}

--- a/plugins/lyrics-genius/front.js
+++ b/plugins/lyrics-genius/front.js
@@ -37,7 +37,7 @@ module.exports = () => {
 		const wrapper = document.createElement("div");
 		wrapper.innerHTML = html;
 
-		const lyrics = Array.from(wrapper.querySelectorAll('[class^="Lyrics__Container"]')).map(d => d.innerHTML).join('<br>')
+		const lyrics = [...wrapper.querySelectorAll('[class^="Lyrics__Container"]')].map(d => d.innerHTML).join('<br>')
 					 || wrapper.querySelector(".lyrics")?.innerHTML;
 
 		if (!lyrics) {


### PR DESCRIPTION
Previously lyrics would come from `querySelector('[class^="Lyrics__Container"]')`, but genius sometimes have multiple lyrics div's for the same song, for example https://genius.com/Built-to-spill-velvet-waltz-lyrics

this PR change the lyrics to come from querySelectorAll and join their inner html with `<br>`

fix #664 

notes:

* `lyricsSelector1 = Array.from(querySelectorAll(...))....join(...)` is safe since
  * `querySelectorAll` returns an empty `NodeList` if none are found
  *  `Array.from(EmptyNodeList)` returns an empty array (switched to spread syntax but same behavior)
  * `EmptyArray.join(..)` returns empty string

* commit history is messy and should be squashed
