### PR TITLE
MacOS: bring back the app in dock when using tray + app hidden

### DIFF
--- a/tray.js
+++ b/tray.js
@@ -70,7 +70,7 @@ module.exports.setUpTray = (app, win) => {
 				app.quit();
 			},
 		},
-		 { role: "quit" } 
+		{ role: "quit" },
 	];
 
 	const trayMenu = Menu.buildFromTemplate(template);

--- a/tray.js
+++ b/tray.js
@@ -1,6 +1,6 @@
 const path = require("path");
 
-const { Menu, nativeImage, Tray } = require("electron");
+const { app, Menu, nativeImage, Tray } = require("electron");
 
 const config = require("./config");
 const getSongControls = require("./providers/song-controls");
@@ -27,7 +27,13 @@ module.exports.setUpTray = (app, win) => {
 		if (config.get("options.trayClickPlayPause")) {
 			playPause();
 		} else {
-			win.isVisible() ? win.hide() : win.show();
+			if (win.isVisible()) {
+				win.hide();
+				app.dock?.hide();
+			} else {
+				win.show();
+				app.dock?.show();
+			}
 		}
 	});
 
@@ -54,6 +60,7 @@ module.exports.setUpTray = (app, win) => {
 			label: "Show",
 			click: () => {
 				win.show();
+				app.dock?.show();
 			},
 		},
 		{


### PR DESCRIPTION
This PR brings back the app in the MacOS dock when the app is hidden, so that the menu is back available - it should help resolving https://github.com/th-ch/youtube-music/issues/558 (the issue _might_ need additional work).