### PR TITLE
[in-app-menu] add hide icon option

### DIFF
--- a/plugins/in-app-menu/front.js
+++ b/plugins/in-app-menu/front.js
@@ -3,7 +3,7 @@ const config = require("../../config");
 const { Titlebar, Color } = require("custom-electron-titlebar");
 function $(selector) { return document.querySelector(selector); }
 
-module.exports = () => {
+module.exports = (options) => {
 	let visible = !config.get("options.hideMenu");
 	const bar = new Titlebar({
 		backgroundColor: Color.fromHex("#050505"),
@@ -13,6 +13,10 @@ module.exports = () => {
 	});
 	bar.updateTitle(" ");
 	document.title = "Youtube Music";
+
+	const hideIcon = hide => $('.cet-window-icon').style.display = hide ? 'none' : 'flex';
+
+	if (options.hideIcon) hideIcon(true);
 
 	ipcRenderer.on("refreshMenu", (_, showMenu) => {
 		if (showMenu === undefined && !visible) return;
@@ -24,6 +28,8 @@ module.exports = () => {
 			visible = true;
 		}
 	});
+
+	ipcRenderer.on("hideIcon", (_, hide) => hideIcon(hide));
 
 	// Increases the right margin of Navbar background when the scrollbar is visible to avoid blocking it (z-index doesn't affect it)
 	document.addEventListener('apiLoaded', () => {

--- a/plugins/in-app-menu/menu.js
+++ b/plugins/in-app-menu/menu.js
@@ -1,0 +1,14 @@
+const { setOptions } = require("../../config/plugins");
+
+module.exports = (win, options) => [
+    {
+        label: "Hide Icon",
+        type: "checkbox",
+        checked: options.hideIcon,
+        click: (item) => {
+            win.webContents.send("hideIcon", item.checked);
+            options.hideIcon = item.checked;
+            setOptions("in-app-menu", options);
+        },
+    }
+];

--- a/plugins/in-app-menu/style.css
+++ b/plugins/in-app-menu/style.css
@@ -71,3 +71,7 @@ yt-page-navigation-progress,
 	-moz-border-radius: 100px;
 	-webkit-border-radius: 100px;
 }
+
+.cet-menubar-menu-container .cet-action-item {
+	background-color: inherit
+}


### PR DESCRIPTION
* [feat: in-app-menu hideIcon option](https://github.com/th-ch/youtube-music/pull/680/commits/b4b785d77313a0ec5529f150171b316b675bfeab) :
 allows hiding the app icon from the titlebar (this + hideMenu option makes PiP mode really smooth looking)

* [fix: in-app-menu bg color edge case](https://github.com/th-ch/youtube-music/pull/680/commits/8000a8326fb77f81880818b4ce9c854a6ccbd2e3) :
  when elements weren't initially rendered because the window was too small, but were then accessed via the arrow keys - backgrounds were missing for the newly rendered elements
