### PR TITLE
update build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,18 +13,18 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup NodeJS
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "16.x"
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}


### PR DESCRIPTION
primarily aims to fix a weird error in build action:

```Cirru
[3/5] Fetching packages...
info There appears to be trouble with your network connection. Retrying...
error An unexpected error occurred: "https://gitpkg.now.sh/zerodytrash/Simple-YouTube-Age-Restriction-Bypass/dist?v2.4.6: ETIMEDOUT".
info If you think this is a bug, please open a bug report with the information provided in "/home/runner/work/youtube-music/youtube-music/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Process completed with exit code 1.
```
the URL is wrong, there is an extra <kbd>:</kbd> at the end for some reason
updating actions and node seems to fix the issue somehow

> the code block style in this comment (Cirru) was found using https://github.com/Araxeus/gh-linguist-preview 🙂