### PR TITLE
proposal: Adding an option to hide duration before the song ends

### DIFF
--- a/config/defaults.js
+++ b/config/defaults.js
@@ -49,7 +49,7 @@ const defaultConfig = {
 			activityTimoutEnabled: true, // if enabled, the discord rich presence gets cleared when music paused after the time specified below
 			activityTimoutTime: 10 * 60 * 1000, // 10 minutes
 			listenAlong: true, // add a "listen along" button to rich presence
-			displayDurationLeft: true, // add the start and end time of the song to rich presence
+			hideDurationLeft: false, // hides the start and end time of the song to rich presence
 		},
 		notifications: {
 			enabled: false,

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -49,6 +49,7 @@ const defaultConfig = {
 			activityTimoutEnabled: true, // if enabled, the discord rich presence gets cleared when music paused after the time specified below
 			activityTimoutTime: 10 * 60 * 1000, // 10 minutes
 			listenAlong: true, // add a "listen along" button to rich presence
+			displayDurationLeft: true, // add the start and end time of the song to rich presence
 		},
 		notifications: {
 			enabled: false,

--- a/plugins/discord/back.js
+++ b/plugins/discord/back.js
@@ -70,7 +70,7 @@ let clearActivity;
  */
 let updateActivity;
 
-module.exports = (win, { activityTimoutEnabled, activityTimoutTime, listenAlong }) => {
+module.exports = (win, { activityTimoutEnabled, activityTimoutTime, listenAlong, hideDurationLeft }) => {
 	window = win;
 	// We get multiple events
 	// Next song: PAUSE(n), PAUSE(n+1), PLAY(n+1)
@@ -117,7 +117,7 @@ module.exports = (win, { activityTimoutEnabled, activityTimoutTime, listenAlong 
 			// Set start the timer so the activity gets cleared after a while if enabled
 			if (activityTimoutEnabled)
 				clearActivity = setTimeout(() => info.rpc.clearActivity().catch(console.error), activityTimoutTime ?? 10000);
-		} else {
+		} else if (!hideDurationLeft) {
 			// Add the start and end time of the song
 			const songStartTime = Date.now() - songInfo.elapsedSeconds * 1000;
 			activityInfo.startTimestamp = songStartTime;

--- a/plugins/discord/menu.js
+++ b/plugins/discord/menu.js
@@ -41,6 +41,15 @@ module.exports = (win, options, refreshMenu) => {
 			},
 		},
 		{
+			label: "Hide duration left",
+			type: "checkbox",
+			checked: options.hideDurationLeft,
+			click: (item) => {
+				options.hideDurationLeft = item.checked;
+				setMenuOptions('discord', options);
+			}
+		},
+		{
 			label: "Set inactivity timeout",
 			click: () => setInactivityTimeout(win, options),
 		},


### PR DESCRIPTION
It bothers me sometimes when the countdown gets out of the album's "horizontal area", and I think it's more cleaner to remove it.
Therefore, I'm proposing an option to hide the countdown (disabled by default).

![image](https://user-images.githubusercontent.com/82711525/186166821-8c591db6-5e0a-4a7d-a4ae-16dcd18ac8e5.png)
![image](https://user-images.githubusercontent.com/82711525/186166830-ceb2ac3b-8297-43b1-a1e0-e116e4a9b956.png)