### PR TITLE
fix malformed json in tuna-obs

### DIFF
--- a/plugins/tuna-obs/back.js
+++ b/plugins/tuna-obs/back.js
@@ -6,6 +6,7 @@ const registerCallback = require("../../providers/song-info");
 const secToMilisec = t => Math.round(Number(t) * 1e3);
 const data = {
 	cover: '',
+	cover_url: '',
 	title: '',
 	artists: [],
 	status: '',
@@ -42,6 +43,7 @@ module.exports = async (win) => {
 		data.duration = secToMilisec(songInfo.songDuration)
 		data.progress = secToMilisec(songInfo.elapsedSeconds)
 		data.cover = songInfo.imageSrc;
+		data.cover_url = songInfo.imageSrc;
 		data.album_url = songInfo.imageSrc;
 		data.title = songInfo.title;
 		data.artists = [songInfo.artist];

--- a/plugins/tuna-obs/back.js
+++ b/plugins/tuna-obs/back.js
@@ -5,7 +5,7 @@ const registerCallback = require("../../providers/song-info");
 
 const secToMilisec = t => Math.round(Number(t) * 1e3);
 const data = {
-	cover_url: '',
+	cover: '',
 	title: '',
 	artists: [],
 	status: '',
@@ -41,7 +41,7 @@ module.exports = async (win) => {
 
 		data.duration = secToMilisec(songInfo.songDuration)
 		data.progress = secToMilisec(songInfo.elapsedSeconds)
-		data.cover_url = songInfo.imageSrc;
+		data.cover = songInfo.imageSrc;
 		data.album_url = songInfo.imageSrc;
 		data.title = songInfo.title;
 		data.artists = [songInfo.artist];


### PR DESCRIPTION
the tuna web server uses `cover` for the songs cover art, where as we are sending it under `cover_url`.

this lead to tuna failing to find the cover art.

i'm not 100% certain, but i believe this was changed in a somewhat recent version of tuna, so it might require a more indepth fix to stay compatible with older versions.