### PR TITLE
Center toggle of video-toggle

### DIFF
--- a/plugins/video-toggle/button-switcher.css
+++ b/plugins/video-toggle/button-switcher.css
@@ -2,6 +2,10 @@
     align-items: unset !important;
 }
 
+#main-panel {
+    position: relative;
+}
+
 .video-switch-button {
     z-index: 999;
     box-sizing: border-box;
@@ -18,6 +22,7 @@
     color: #fff;
     padding-right: 120px;
     position: absolute;
+    left: calc(50% - 120px);
 }
 
 .video-switch-button:before {

--- a/plugins/video-toggle/button-switcher.css
+++ b/plugins/video-toggle/button-switcher.css
@@ -22,7 +22,7 @@
     color: #fff;
     padding-right: 120px;
     position: absolute;
-    left: calc(50% - 120px);
+    left: var(--align);
 }
 
 .video-switch-button:before {

--- a/plugins/video-toggle/front.js
+++ b/plugins/video-toggle/front.js
@@ -31,6 +31,21 @@ module.exports = (_options) => {
             document.addEventListener("apiLoaded", setup, { once: true, passive: true });
         }
     }
+    const mainpanel = document.querySelector("#main-panel");
+    switch (_options.align) {
+        case "right": {
+            mainpanel.style.setProperty("--align", "calc(100% - 240px)");
+            return;
+        }
+        case "middle": {
+            mainpanel.style.setProperty("--align", "calc(50% - 120px)");
+            return;
+        }
+        default:
+        case "left": {
+            mainpanel.style.setProperty("--align", "0px");
+        }
+    }
 };
 
 function setup(e) {

--- a/plugins/video-toggle/front.js
+++ b/plugins/video-toggle/front.js
@@ -38,7 +38,7 @@ function setup(e) {
     player = $('ytmusic-player');
     video = $('video');
 
-    $('ytmusic-player-page').prepend(switchButtonDiv);
+    $('#main-panel').append(switchButtonDiv);
 
     if (options.hideVideo) {
         $('.video-switch-button-checkbox').checked = false;

--- a/plugins/video-toggle/menu.js
+++ b/plugins/video-toggle/menu.js
@@ -34,6 +34,38 @@ module.exports = (win, options) => [
         ]
     },
     {
+        label: "Alignment",
+        submenu: [
+            {
+                label: "Left",
+                type: "radio",
+                checked: options.align === 'left',
+                click: () => {
+                    options.align = 'left';
+                    setMenuOptions("video-toggle", options);
+                }
+            },
+            {
+                label: "Middle",
+                type: "radio",
+                checked: options.align === 'middle',
+                click: () => {
+                    options.align = 'middle';
+                    setMenuOptions("video-toggle", options);
+                }
+            },
+            {
+                label: "Right",
+                type: "radio",
+                checked: options.align === 'right',
+                click: () => {
+                    options.align = 'right';
+                    setMenuOptions("video-toggle", options);
+                }
+            },
+        ]
+    },
+    {
         label: "Force Remove Video Tab",
         type: "checkbox",
         checked: options.forceHide,


### PR DESCRIPTION
Appended video-toggle to `#main-panel` so it can be centered over the video.
Centered it through setting left to `50% - 120px` and set position of `#main-panel` to relative that it uses this to center.