### PR TITLE
Fixed video-toggle aligning running before #main-panel exists

### DIFF
--- a/plugins/video-toggle/button-switcher.css
+++ b/plugins/video-toggle/button-switcher.css
@@ -22,7 +22,6 @@
     color: #fff;
     padding-right: 120px;
     position: absolute;
-    left: var(--align);
 }
 
 .video-switch-button:before {

--- a/plugins/video-toggle/front.js
+++ b/plugins/video-toggle/front.js
@@ -31,21 +31,6 @@ module.exports = (_options) => {
             document.addEventListener("apiLoaded", setup, { once: true, passive: true });
         }
     }
-    const mainpanel = document.querySelector("#main-panel");
-    switch (_options.align) {
-        case "right": {
-            mainpanel.style.setProperty("--align", "calc(100% - 240px)");
-            return;
-        }
-        case "middle": {
-            mainpanel.style.setProperty("--align", "calc(50% - 120px)");
-            return;
-        }
-        default:
-        case "left": {
-            mainpanel.style.setProperty("--align", "0px");
-        }
-    }
 };
 
 function setup(e) {
@@ -73,6 +58,21 @@ function setup(e) {
     video.addEventListener('srcChanged', videoStarted);
 
     observeThumbnail();
+
+    switch (options.align) {
+        case "right": {
+            switchButtonDiv.style.left = "calc(100% - 240px)";
+            return;
+        }
+        case "middle": {
+            switchButtonDiv.style.left = "calc(50% - 120px)";
+            return;
+        }
+        default:
+        case "left": {
+            switchButtonDiv.style.left = "0px";
+        }
+    }
 }
 
 function changeDisplay(showVideo) {


### PR DESCRIPTION
> This can possibly break the plugin (and it did for me, multiple time) `Cannot read properties of undefined.` `mainpanel.style.setProperty("--align", "0px");`
> 
> this whole code block needs to be inside an `apiLoaded` closure, we can't guarantee that `$('#main-panel')` exists when this code is called
> 
> In other words, instead of being inside the default export function, it should be inside the `setup` function which is called only when the page is loaded
> 
> @MiepHD @th-ch plz fix