### PR TITLE
[in-app-menu] make navbar draggable

### DIFF
--- a/plugins/in-app-menu/front.js
+++ b/plugins/in-app-menu/front.js
@@ -43,8 +43,20 @@ module.exports = (options) => {
 		setNavbarMargin();
 		const playPageObserver = new MutationObserver(setNavbarMargin);
 		playPageObserver.observe($('ytmusic-app-layout'), { attributeFilter: ['player-page-open_', 'playerPageOpen_'] })
+		setupSearchOpenObserver();
 	}, { once: true, passive: true })
 };
+
+function setupSearchOpenObserver() {
+	const searchOpenObserver = new MutationObserver(mutations => {
+		if (mutations[0].target.opened) {
+			$('#nav-bar-background').style.webkitAppRegion = 'no-drag'
+		} else {
+			$('#nav-bar-background').style.webkitAppRegion = 'drag'
+		}
+	});
+	searchOpenObserver.observe($('ytmusic-search-box'), { attributeFilter: ["opened"] })
+}
 
 function setNavbarMargin() {
 	$('#nav-bar-background').style.right =

--- a/plugins/in-app-menu/front.js
+++ b/plugins/in-app-menu/front.js
@@ -49,11 +49,8 @@ module.exports = (options) => {
 
 function setupSearchOpenObserver() {
 	const searchOpenObserver = new MutationObserver(mutations => {
-		if (mutations[0].target.opened) {
-			$('#nav-bar-background').style.webkitAppRegion = 'no-drag'
-		} else {
-			$('#nav-bar-background').style.webkitAppRegion = 'drag'
-		}
+		$('#nav-bar-background').style.webkitAppRegion =
+			mutations[0].target.opened ? 'no-drag' : 'drag';
 	});
 	searchOpenObserver.observe($('ytmusic-search-box'), { attributeFilter: ["opened"] })
 }

--- a/plugins/in-app-menu/style.css
+++ b/plugins/in-app-menu/style.css
@@ -80,3 +80,15 @@ yt-page-navigation-progress,
 .cet-menubar-menu-container .cet-action-item {
 	background-color: inherit
 }
+
+#nav-bar-background {
+    -webkit-app-region: drag;
+}
+
+ytmusic-nav-bar input,
+ytmusic-nav-bar span,
+ytmusic-nav-bar [role="button"],
+ytmusic-nav-bar yt-icon,
+tp-yt-iron-dropdown {
+    -webkit-app-region: no-drag;
+}


### PR DESCRIPTION
Dragging the navbar moves the window, except when clicking its elements

`searchOpenObserver` purpose is to allow closing the searchbox by clicking outside of it.
If the navbar is draggable, the click event doesn't go through – so it needs to not be draggable when the searchbox is open.