### PR TITLE
Build without release in forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     name: Release YouTube Music
-    if: github.ref == 'refs/heads/master'
+    if: github.repository == 'th-ch/youtube-music' && github.ref == 'refs/heads/master'
     needs: build
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,26 +65,43 @@ jobs:
         with:
           run: yarn test
 
-      - name: Build on Mac
-        if: startsWith(matrix.os, 'macOS')
+      # Build and release if it's the main repository
+      - name: Build and release on Mac
+        if: startsWith(matrix.os, 'macOS') && github.repository == 'th-ch/youtube-music'
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           yarn run release:mac
 
-      - name: Build on Linux
-        if: startsWith(matrix.os, 'ubuntu')
+      - name: Build and release on Linux
+        if: startsWith(matrix.os, 'ubuntu') && github.repository == 'th-ch/youtube-music'
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           yarn run release:linux
 
-      - name: Build on Windows
-        if: startsWith(matrix.os, 'windows')
+      - name: Build and release on Windows
+        if: startsWith(matrix.os, 'windows') && github.repository == 'th-ch/youtube-music'
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           yarn run release:win
+
+      # Only build without release if it is a fork
+      - name: Build on Mac
+        if: startsWith(matrix.os, 'macOS') && github.repository != 'th-ch/youtube-music'
+        run: |
+          yarn run build:mac
+
+      - name: Build on Linux
+        if: startsWith(matrix.os, 'ubuntu') && github.repository != 'th-ch/youtube-music'
+        run: |
+          yarn run build:linux
+
+      - name: Build on Windows
+        if: startsWith(matrix.os, 'windows') && github.repository != 'th-ch/youtube-music'
+        run: |
+          yarn run build:win
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR is a proposal following https://github.com/th-ch/youtube-music/pull/1022#issuecomment-1424838707 to change the CI to build without release in forks, which should avoid errors linked to the missing GH token.