### PR TITLE
[PiP] fix hotkey activating when typing in the search box

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,8 @@
 		"filenamify": "^4.3.0",
 		"howler": "^2.2.3",
 		"html-to-text": "^9.0.3",
+		"keyboardevent-from-electron-accelerator": "^2.0.0",
+		"keyboardevents-areequal": "^0.2.2",
 		"md5": "^2.3.0",
 		"mpris-service": "^2.1.2",
 		"node-fetch": "^2.6.8",

--- a/plugins/picture-in-picture/back.js
+++ b/plugins/picture-in-picture/back.js
@@ -103,9 +103,6 @@ module.exports = (_win, _options) => {
 	ipcMain.on("picture-in-picture", async () => {
 		await togglePiP();
 	});
-	if (options.hotkey) {
-		electronLocalshortcut.register(win, options.hotkey, togglePiP);
-	}
 };
 
 module.exports.setOptions = setLocalOptions;

--- a/plugins/picture-in-picture/front.js
+++ b/plugins/picture-in-picture/front.js
@@ -1,5 +1,8 @@
 const { ipcRenderer } = require("electron");
 
+const { toKeyEvent } = require('keyboardevent-from-electron-accelerator');
+const keyEventAreEqual = require('keyboardevents-areequal');
+
 const { getSongMenu } = require("../../providers/dom-elements");
 const { ElementFromFile, templatePath } = require("../utils");
 
@@ -74,13 +77,13 @@ const listenForToggle = () => {
 	});
 }
 
-function observeMenu(options) {
+function observeMenu() {
 	document.addEventListener(
 		"apiLoaded",
 		() => {
 			listenForToggle();
 			// remove native listeners
-			cloneButton(".player-minimize-button").onclick = () =>  {
+			cloneButton(".player-minimize-button").onclick = () => {
 				global.togglePictureInPicture();
 				setTimeout(() => $('#player').click());
 			};
@@ -97,4 +100,15 @@ function observeMenu(options) {
 	);
 }
 
-module.exports = observeMenu;
+module.exports = (options) => {
+	observeMenu();
+
+	if (options.hotkey) {
+		const hotkeyEvent = toKeyEvent(options.hotkey);
+		window.addEventListener('keydown', (event) => {
+			if (keyEventAreEqual(event, hotkeyEvent) && !$('ytmusic-search-box').opened) {
+				togglePictureInPicture();
+			}
+		});
+	}
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5518,7 +5518,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keyboardevents-areequal@npm:^0.2.1":
+"keyboardevents-areequal@npm:^0.2.1, keyboardevents-areequal@npm:^0.2.2":
   version: 0.2.2
   resolution: "keyboardevents-areequal@npm:0.2.2"
   checksum: 05d846f75170238bbb9ed45d13ca9c6cd3e68ea8ba6b7727971790fa55b44c3386ec8b9c321ae72dae0d0944678d0dc2b922148fe67d3f9720bf30a23999dd65
@@ -8979,6 +8979,8 @@ __metadata:
     filenamify: ^4.3.0
     howler: ^2.2.3
     html-to-text: ^9.0.3
+    keyboardevent-from-electron-accelerator: ^2.0.0
+    keyboardevents-areequal: ^0.2.2
     md5: ^2.3.0
     mpris-service: ^2.1.2
     node-fetch: ^2.6.8


### PR DESCRIPTION
fix #843

The added dependencies are part of `electron-local-shortcut` so they are already included.

I've added them to package.json/yarn.lock just in case we switch to ESM down the line