### PR TITLE
Fix playback speed slider not showing and PiP button showing when it shouldn't

### DIFF
--- a/plugins/picture-in-picture/front.js
+++ b/plugins/picture-in-picture/front.js
@@ -30,7 +30,7 @@ const observer = new MutationObserver(() => {
 		menu = getSongMenu();
 		if (!menu) return;
 	}
-	if (menu.contains(pipButton)) return;
+	if (menu.contains(pipButton) || !menu.parentElement.eventSink_?.matches('ytmusic-menu-renderer.ytmusic-player-bar')) return;
 	const menuUrl = $(
 		'tp-yt-paper-listbox [tabindex="0"] #navigation-endpoint'
 	)?.href;

--- a/plugins/playback-speed/front.js
+++ b/plugins/playback-speed/front.js
@@ -30,7 +30,7 @@ const observePopupContainer = () => {
 			menu = getSongMenu();
 		}
 
-		if (menu && menu.lastElementChild.lastElementChild.innerText.startsWith('Stats') && !menu.contains(slider)) {
+		if (menu && menu.parentElement.eventSink_?.matches('ytmusic-menu-renderer.ytmusic-player-bar') && !menu.contains(slider)) {
 			menu.prepend(slider);
 			if (!observingSlider) {
 				setupSliderListener();


### PR DESCRIPTION
Replace querying for the text `Stats` (which is language specific) with querying that the event origin is the button on the player-bar

Applies to both playback-speed (fix #1045) and PiP which actually didn't even check till now