### PR TITLE
[in-app-menu] disable nav-bar drag when menu is open

### DIFF
--- a/plugins/in-app-menu/front.js
+++ b/plugins/in-app-menu/front.js
@@ -44,6 +44,7 @@ module.exports = (options) => {
 		const playPageObserver = new MutationObserver(setNavbarMargin);
 		playPageObserver.observe($('ytmusic-app-layout'), { attributeFilter: ['player-page-open_', 'playerPageOpen_'] })
 		setupSearchOpenObserver();
+		setupMenuOpenObserver();
 	}, { once: true, passive: true })
 };
 
@@ -53,6 +54,15 @@ function setupSearchOpenObserver() {
 			mutations[0].target.opened ? 'no-drag' : 'drag';
 	});
 	searchOpenObserver.observe($('ytmusic-search-box'), { attributeFilter: ["opened"] })
+}
+
+function setupMenuOpenObserver() {
+	const menuOpenObserver = new MutationObserver(mutations => {
+		$('#nav-bar-background').style.webkitAppRegion =
+			Array.from($('.cet-menubar').childNodes).some(c => c.classList.contains('open')) ?
+				'no-drag' : 'drag';
+	});
+	menuOpenObserver.observe($('.cet-menubar'), { subtree: true, attributeFilter: ["class"] })
 }
 
 function setNavbarMargin() {


### PR DESCRIPTION
Fix a bug originating from #989 

The nav-bar drag bugs out normal pointer events in its area, so it needs to be disabled when the menu is open
fix #1037 