### PR TITLE
Add dynamic synced plugin config provider

### DIFF
--- a/config/dynamic.js
+++ b/config/dynamic.js
@@ -67,7 +67,7 @@ module.exports.PluginConfig = class PluginConfig {
 	};
 
 	setAll = (options) => {
-		this.#config = { ...options };
+		this.#config = { ...this.#config, ...options };
 		this.#save();
 	};
 

--- a/config/dynamic.js
+++ b/config/dynamic.js
@@ -1,0 +1,112 @@
+const { ipcRenderer, ipcMain } = require("electron");
+
+const defaultConfig = require("./defaults");
+const { getOptions, setOptions, setMenuOptions } = require("./plugins");
+
+/**
+ * This class is used to create a dynamic synced config for plugins.
+ *
+ * [!IMPORTANT!]
+ * The methods are **sync** in the main process and **async** in the renderer process.
+ *
+ * @param {string} name - The name of the plugin.
+ * @param {boolean} [options.enableFront] - Whether the config should be available in front.js. Default: false.
+ * @param {object} [options.initialOptions] - The initial options for the plugin. Default: loaded from store.
+ *
+ * @example
+ * const { PluginConfig } = require("../../config/dynamic");
+ * const config = new PluginConfig("plugin-name", { enableFront: true });
+ * module.exports = { ...config };
+ * 
+ * // or
+ * 
+ * module.exports = (win, options) => {
+ *  const config = new PluginConfig("plugin-name", {
+ *  	enableFront: true,
+ *  	initialOptions: options,
+ *  });
+ *  setupMyPlugin(win, config);
+ * };
+ */
+module.exports.PluginConfig = class PluginConfig {
+	#name;
+	#config;
+	#defaultConfig;
+	#enableFront;
+
+	constructor(name, { enableFront = false, initialOptions = undefined } = {}) {
+		const pluginDefaultConfig = defaultConfig.plugins[name] || {};
+		const pluginConfig = initialOptions || getOptions(name) || {};
+
+		this.#name = name;
+		this.#enableFront = enableFront;
+		this.#defaultConfig = pluginDefaultConfig;
+		this.#config = { ...pluginDefaultConfig, ...pluginConfig };
+
+		if (this.#enableFront) {
+			this.#setupFront();
+		}
+	}
+
+	get = (option) => {
+		return this.#config[option];
+	};
+
+	set = (option, value) => {
+		this.#config[option] = value;
+		this.#save();
+	};
+
+	toggle = (option) => {
+		this.#config[option] = !this.#config[option];
+		this.#save();
+	};
+
+	getAll = () => {
+		return { ...this.#config };
+	};
+
+	setAll = (options) => {
+		this.#config = { ...options };
+		this.#save();
+	};
+
+	getDefaultConfig = () => {
+		return this.#defaultConfig;
+	};
+
+	/**
+	 * Use this method to set an option and restart the app if `appConfig.restartOnConfigChange === true`
+	 *
+	 * Used for options that require a restart to take effect.
+	 */
+	setAndMaybeRestart = (option, value) => {
+		this.#config[option] = value;
+		setMenuOptions(this.#name, this.#config);
+	};
+
+	#save() {
+		setOptions(this.#name, this.#config);
+	}
+
+	#setupFront() {
+		if (process.type === "renderer") {
+			for (const [fnName, fn] of Object.entries(this)) {
+				if (typeof fn !== "function") return;
+				this[fnName] = async (...args) => {
+					return await ipcRenderer.invoke(
+						`${this.name}-config-${fnName}`,
+						...args,
+					);
+				};
+			}
+		} else if (process.type === "browser") {
+			for (const [fnName, fn] of Object.entries(this)) {
+				if (typeof fn !== "function") return;
+				ipcMain.handle(`${this.name}-config-${fnName}`, (_, ...args) => {
+					return fn(...args);
+				});
+			}
+		}
+	}
+};

--- a/plugins/notifications/back.js
+++ b/plugins/notifications/back.js
@@ -39,7 +39,6 @@ const setup = () => {
 
 /** @param {Electron.BrowserWindow} win */
 module.exports = (win, options) => {
-	config.init(options);
 	// Register the callback for new song information
 	is.windows() && options.interactive ?
 		require("./interactive")(win) :

--- a/plugins/notifications/config.js
+++ b/plugins/notifications/config.js
@@ -1,23 +1,5 @@
-const { setOptions, setMenuOptions } = require("../../config/plugins");
-const defaultConfig = require("../../config/defaults");
+const { PluginConfig } = require("../../config/dynamic");
 
-let config = defaultConfig.plugins["notifications"];
+const config = new PluginConfig("notifications");
 
-module.exports.init = (options) => {
-	config = { ...config, ...options };
-};
-
-module.exports.setAndMaybeRestart = (option, value) => {
-	config[option] = value;
-	setMenuOptions("notifications", config);
-};
-
-module.exports.set = (option, value) => {
-	config[option] = value;
-	setOptions("notifications", config);
-};
-
-module.exports.get = (option) => {
-	let res = config[option];
-	return res;
-};
+module.exports = { ...config };


### PR DESCRIPTION
> There are atleast 3 open PR's which could use this: #1054 , #1065 and #1079

# Synced PluginConfig

This PR allows all plugin to easily have access to synced config on both main & renderer (back/front)
> This is potentialy very useful, after all plugins implement this class - *most* plugin options shouldn't require a restart to apply

----
## Example

in `./plugins/my-plugin/config.js`:

```js
 const { PluginConfig } = require("../../config/dynamic");
 const config = new PluginConfig("plugin-name", { enableFront: true });
 module.exports = { ...config };
 ```

----

in `./plugins/my-plugin/back.js`:
```js
const config = require("./config");

config.set("myOption", true)

assert.equal(config.get("myOption"), true);
```

----

in `./plugins/my-plugin/front.js`:
```js
const config = require("./config");

await config.set("myOption", true)

assert.equal(
  await config.get("myOption"),
  true,
);
```

## Example 2

The config could also be initialized straight from back.js (tho I doubt there's ever a reason to do that)
```js
 module.exports = (win, options) => {
  const config = new PluginConfig("plugin-name", {
  	enableFront: true,
  	initialOptions: options,
  });
  setupMyPlugin(win, config);
 };
```

## TODO

* https://github.com/th-ch/youtube-music/pull/1064/commits/a6242d13aecca8b9b6148a0f4bf8b1a504d2b66a adds support for  `getActivePlugins` and `isActive`. need to implement in plugins where we want it instead of `isEnabled`
 Find use cases here: https://github.com/search?q=repo%3Ath-ch%2Fyoutube-music+enabled+path%3Aplugins&type=code

