### PR TITLE
[in-app-menu] fix items hidden by navbar in library

### DIFF
--- a/plugins/in-app-menu/style.css
+++ b/plugins/in-app-menu/style.css
@@ -12,9 +12,15 @@
 	height: 75px !important;
 }
 
-/* fixes top gap between nav-bar and browse-page */
+/* fix top gap between nav-bar and browse-page */
 #browse-page {
 	padding-top: 0 !important;
+}
+
+/* fix navbar hiding library items */
+ytmusic-section-list-renderer[page-type="MUSIC_PAGE_TYPE_LIBRARY_CONTENT_LANDING_PAGE"] {
+	top: 50px;
+    position: relative;
 }
 
 /* remove window dragging for nav bar (conflict with titlebar drag) */


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/78568641/224562714-e5810f0b-0920-430b-bc5b-53cf217a8d19.png)


after:
![image](https://user-images.githubusercontent.com/78568641/224562493-997147eb-a40e-4d62-927a-1d00ef608a15.png)
