### PR TITLE
[in-app-menu] fix css style of the library of uploaded songs

### DIFF
--- a/plugins/in-app-menu/style.css
+++ b/plugins/in-app-menu/style.css
@@ -18,7 +18,8 @@
 }
 
 /* fix navbar hiding library items */
-ytmusic-section-list-renderer[page-type="MUSIC_PAGE_TYPE_LIBRARY_CONTENT_LANDING_PAGE"] {
+ytmusic-section-list-renderer[page-type="MUSIC_PAGE_TYPE_LIBRARY_CONTENT_LANDING_PAGE"],
+ytmusic-section-list-renderer[page-type="MUSIC_PAGE_TYPE_PRIVATELY_OWNED_CONTENT_LANDING_PAGE"] {
 	top: 50px;
     position: relative;
 }


### PR DESCRIPTION
follows up on  [in-app-menu] fix items hidden by navbar in library #1067

this is exactly the same fix, but now it also applies to the uploaded songs library (which is a different page)