### PR TITLE
add option to hide the like buttons

### DIFF
--- a/config/store.js
+++ b/config/store.js
@@ -19,6 +19,11 @@ const migrations = {
 				...pluginOptions,
 			});
 		}
+
+		if (store.get("options.ForceShowLikeButtons")) {
+			store.delete("options.ForceShowLikeButtons");
+			store.set("options.likeButtons", 'force');
+		}
 	},
 	">=1.17.0": (store) => {
 		setDefaultPluginOptions(store, "picture-in-picture");

--- a/menu.js
+++ b/menu.js
@@ -93,12 +93,33 @@ const mainMenuTemplate = (win) => {
 							},
 						},
 						{
-							label: "Force show like buttons",
-							type: "checkbox",
-							checked: config.get("options.ForceShowLikeButtons"),
-							click: (item) => {
-								config.set("options.ForceShowLikeButtons", item.checked);
-							},
+							label: "Like buttons",
+							submenu: [
+								{
+									label: "Default",
+									type: "radio",
+									checked: !config.get("options.likeButtons"),
+									click: () => {
+										config.set("options.likeButtons", '');
+									},
+								},
+								{
+									label: "Force show",
+									type: "radio",
+									checked: config.get("options.likeButtons") === 'force',
+									click: () => {
+										config.set("options.likeButtons", 'force');
+									}
+								},
+								{
+									label: "Hide",
+									type: "radio",
+									checked: config.get("options.likeButtons") === 'hide',
+									click: () => {
+										config.set("options.likeButtons", 'hide');
+									}
+								},
+							],
 						},
 						{
 							label: "Theme",

--- a/preload.js
+++ b/preload.js
@@ -135,11 +135,17 @@ function onApiLoaded() {
 		}
 	}
 
-	// Force show like buttons
-	if (config.get("options.ForceShowLikeButtons")) {
-		const likeButtons = document.querySelector('ytmusic-like-button-renderer')
+
+	// Hide / Force show like buttons
+	const likeButtonsOptions = config.get("options.likeButtons");
+	if (likeButtonsOptions) {
+		const likeButtons = document.querySelector("ytmusic-like-button-renderer");
 		if (likeButtons) {
-			likeButtons.style.display = 'inherit';
+			likeButtons.style.display =
+				{
+					hide: "none",
+					force: "inherit",
+				}[likeButtonsOptions] || "";
 		}
 	}
 }


### PR DESCRIPTION
Now you can select if the like buttons style should be `Default` / `Force Show` / `Hidden`
fix #1075 

![image](https://user-images.githubusercontent.com/78568641/225698077-7f2d59e8-dbd0-4115-ad1a-d56a5836d063.png)

also added migrations

