### PR TITLE
[downloader] Cleanup metadata

### DIFF
--- a/plugins/downloader/back.js
+++ b/plugins/downloader/back.js
@@ -8,7 +8,7 @@ const { join } = require('path');
 
 const { fetchFromGenius } = require('../lyrics-genius/back');
 const { isEnabled } = require('../../config/plugins');
-const { getImage } = require('../../providers/song-info');
+const { getImage, cleanupName } = require('../../providers/song-info');
 const { injectCSS } = require('../utils');
 const {
   presets,
@@ -514,10 +514,10 @@ const getVideoId = (url) => {
 
 const getMetadata = (info) => ({
   id: info.basic_info.id,
-  title: info.basic_info.title,
-  artist: info.basic_info.author,
+  title: cleanupName(info.basic_info.title),
+  artist: cleanupName(info.basic_info.author),
   album: info.player_overlays?.browser_media_session?.album?.text,
-  image: info.basic_info.thumbnail[0].url,
+  image: info.basic_info.thumbnail?.find((t) => !t.url.endsWith('.webp'))?.url,
 });
 
 // This is used to bypass age restrictions


### PR DESCRIPTION
* Title and artist gets cleaned as before
  (fix downloaded songs having things like `(Official Video)` in them)

* We now ignore thumbnail that ends with `.webp` since we can't work with them
  (fix some downloaded songs not having a cover image)

here's an example response that has webp images:

```json
  "basic_info": {
    "id": "dCCXq9QB-dQ",
    "title": "alt-J - Hunger Of The Pine (Official Video)",
    "thumbnail": [
      {
        "url": "https://i.ytimg.com/vi_webp/dCCXq9QB-dQ/hq720.webp",
        "width": 1280,
        "height": 720
      },
      {
        "url": "https://i.ytimg.com/vi/dCCXq9QB-dQ/hq720.jpg?sqp=-oaymwEXCKAGEMIDSFryq4qpAwkIARUAAIhCGAE=&rs=AOn4CLDiJ6pNRAG_kgucwa3TO5-bnrFj1w",
        "width": 800,
        "height": 450
      },
      {
        "url": "https://i.ytimg.com/vi/dCCXq9QB-dQ/hqdefault.jpg?sqp=-oaymwEXCJADEOABSFryq4qpAwkIARUAAIhCGAE=&rs=AOn4CLCqiC42bKeHe7cJXdBe0QvI5XORDw",
        "width": 400,
        "height": 224
      },
      {
        "url": "https://i.ytimg.com/vi_webp/dCCXq9QB-dQ/mqdefault.webp",
        "width": 320,
        "height": 180
      }
    ]
}
```

Or if you want to see the full response for some reason, It's inside the zip below:

[youtubejs-response.zip](https://github.com/th-ch/youtube-music/files/11083028/youtubejs-response.zip)



