### PR TITLE
[crossfade] add `[beta]` tag to warn of possible bugs

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -59,7 +59,12 @@ const mainMenuTemplate = (win) => {
 						};
 					}
 
-					return pluginEnabledMenu(plugin);
+					let pluginLabel = plugin;
+					if (pluginLabel === "crossfade") {
+						pluginLabel = "crossfade [beta]";
+					}
+
+					return pluginEnabledMenu(plugin, pluginLabel);
 				}),
 			],
 		},

--- a/plugins/crossfade/front.js
+++ b/plugins/crossfade/front.js
@@ -111,6 +111,9 @@ const onApiLoaded = () => {
 	watchVideoIDChanges(async (videoID) => {
 		await waitForTransition;
 		const url = await getStreamURL(videoID);
+		if (!url) {
+			return;
+		}
 		await createAudioForCrossfade(url);
 	});
 };


### PR DESCRIPTION
The crossfade plugin is quite buggy at the moment, so I'm adding a tag to warn users

I can't quite figure out what's going on with it, maybe @th-ch can since he wrote it?

see #1078
