### PR TITLE
Protocol handler arguments are not correctly parsed

### DIFF
--- a/index.js
+++ b/index.js
@@ -381,7 +381,7 @@ app.on("ready", () => {
 		const uri = `${APP_PROTOCOL}://`;
 		const protocolArgv = commandLine.find(arg => arg.startsWith(uri));
 		if (protocolArgv) {
-			const command = protocolArgv.slice(uri.length, -1);
+			const command = protocolArgv.slice(uri.length);
 			if (is.dev()) console.debug(`Received command over protocol: "${command}"`);
 			handleProtocol(command);
 			return;


### PR DESCRIPTION
The last character from a protocol handler argument is removed, so the argument won't be parsed correctly to call the requested song control function.

So executing youtubemusic://playPause will be parsed to playPaus, on the other hand executing youtubemusic://playPauseX will trigger the playPause song control.