### PR TITLE
fix protocol handler on unix

### DIFF
--- a/index.js
+++ b/index.js
@@ -381,7 +381,8 @@ app.on("ready", () => {
 		const uri = `${APP_PROTOCOL}://`;
 		const protocolArgv = commandLine.find(arg => arg.startsWith(uri));
 		if (protocolArgv) {
-			const command = protocolArgv.slice(uri.length, -1);
+			const lastIndex = protocolArgv.endsWith("/") ? -1 : undefined;
+			const command = protocolArgv.slice(uri.length, lastIndex);
 			if (is.dev()) console.debug(`Received command over protocol: "${command}"`);
 			handleProtocol(command);
 			return;


### PR DESCRIPTION
on Windows the arg gets appended with `/` but not on Unix

see #1098