### PR TITLE
.gitattributes set `eol=lf` on *all* files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-* text=auto
-*.js text eol=lf
+* text=auto eol=lf
+*.js text


### PR DESCRIPTION
I don't think there's any reason for specifically js files to have different EOL.

Not having a standart EOL made me have some weird diffs when using WSL