### PR TITLE
add xesam:url mpris from songInfo.url

### DIFF
--- a/plugins/shortcuts/mpris.js
+++ b/plugins/shortcuts/mpris.js
@@ -145,6 +145,7 @@ function registerMPRIS(win) {
 					'mpris:length': secToMicro(songInfo.songDuration),
 					'mpris:artUrl': songInfo.imageSrc,
 					'xesam:title': songInfo.title,
+					'xesam:url': songInfo.url,
 					'xesam:artist': [songInfo.artist],
 					'mpris:trackid': '/'
 				};


### PR DESCRIPTION
there's an unused mpris property, xesam:url...
which might be useful for people making their own integrations to show what's currently playing on different platforms and integrations. (I use it to show what's playing on youtube-music on my website)

anyways, just a property add, fetching the url from songInfo.url
seems minor

thx