### PR TITLE
add player method "open" for mpris

### DIFF
--- a/plugins/shortcuts/mpris.js
+++ b/plugins/shortcuts/mpris.js
@@ -95,6 +95,7 @@ function registerMPRIS(win) {
 		player.on('shuffle', (enableShuffle) => {
 			shuffle();
 		});
+                player.on('open', (args) => {win.loadURL(args.uri)});
 
 		let mprisVolNewer = false;
 		let autoUpdate = false;


### PR DESCRIPTION
small addition (just one line)
add functionality for the `playerctl open url` command.
opens the given uri through win.loadURL(url), if there is a better method, please edit/suggest.

perhaps we could also add regex checking for url to see if it's a valid url and it's music.youtub.com one, youtube also sometimes shortens urls so that might be a little complex. 
these are first set of commits/programs for js, so I'm not that proficient :grimacing: 