### PR TITLE
Fix Remove upgrade button

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -139,7 +139,7 @@ function onApiLoaded() {
 
 	// Remove upgrade button
 	if (config.get("options.removeUpgradeButton")) {
-		const upgradeButton = $('ytmusic-pivot-bar-item-renderer[tab-id="SPunlimited"]')
+		const upgradeButton = $('ytmusic-guide-section-renderer #items:last-child') // Last child of #items
 		if (upgradeButton) {
 			upgradeButton.style.display = "none";
 		}

--- a/preload.js
+++ b/preload.js
@@ -139,10 +139,13 @@ function onApiLoaded() {
 
 	// Remove upgrade button
 	if (config.get("options.removeUpgradeButton")) {
-		const upgradeButton = $('ytmusic-guide-section-renderer #items:last-child') // Last child of #items
-		if (upgradeButton) {
-			upgradeButton.style.display = "none";
-		}
+		const styles = document.createElement("style");
+		styles.innerHTML = `
+			ytmusic-guide-section-renderer #items ytmusic-guide-entry-renderer:last-child {
+				display: none;
+			}
+		`;
+		document.head.appendChild(styles);
 	}
 
 


### PR DESCRIPTION
Since last visual update from YouTube, the Remove upgrade button visual tweak does not work.

I made this fix, seems to work on my PC, but since it's just some CSS I don't think there is any reason it would not work on some other platform.

