### PR TITLE
Change Winget Releaser job to `ubuntu-latest`

### DIFF
--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   winget:
     name: Publish winget package
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Submit package to Windows Package Manager Community Repository
         uses: vedantmgoyal2009/winget-releaser@v2


### PR DESCRIPTION
Winget Releaser now supports non-Windows runners, and `ubuntu-latest` is generally faster.