### PR TITLE
feat: use nsis-web instead of nsis

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
       "icon": "assets/generated/icons/win/icon.ico",
       "target": [
         {
-          "target": "nsis",
+          "target": "nsis-web",
           "arch": [
             "x64",
             "ia32",
@@ -76,7 +76,7 @@
         }
       ]
     },
-    "nsis": {
+    "nsisWeb": {
       "runAfterFinish": false
     },
     "linux": {
@@ -119,7 +119,7 @@
     "dist:mac": "npm run clean && npm run build && electron-builder --mac dmg:x64 -p never",
     "dist:mac:arm64": "npm run clean && npm run build && electron-builder --mac dmg:arm64 -p never",
     "dist:win": "npm run clean && npm run build && electron-builder --win -p never",
-    "dist:win:x64": "npm run clean && npm run build && electron-builder --win nsis:x64 -p never",
+    "dist:win:x64": "npm run clean && npm run build && electron-builder --win nsis-web:x64 -p never",
     "lint": "eslint .",
     "changelog": "auto-changelog",
     "plugins": "npm run plugin:bypass-age-restrictions",

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,16 @@ file).*
 winget install th-ch.YouTubeMusic
 ```
 
+#### How to install without a network connection? (in Windows)
+
+- Download the `*.nsis.7z` file for _your device architecture_ in [release page](https://github.com/th-ch/youtube-music/releases/latest).
+  - `x64` for 64-bit Windows
+  - `ia32` for 32-bit Windows
+  - `arm64` for ARM64 Windows
+- Download installer in release page. (`*-Setup.exe`)
+- Place them in the **same directory**.
+- Run the installer.
+
 ## Available plugins:
 
 - **Ad Blocker**: Block all ads and tracking out of the box


### PR DESCRIPTION
- resolves #1265

### How to install without a network? (Windows)

- To install the application offline, download the 7z file and the installer and place them in the same directory.