### PR TITLE
Fix in-app-menu squishing sub-menu items

### DIFF
--- a/plugins/in-app-menu/menu/panel.ts
+++ b/plugins/in-app-menu/menu/panel.ts
@@ -101,6 +101,15 @@ export const createPanel = (
     }
 
     panel.setAttribute('open', 'true');
+
+    // Children are placed below their parent item, which can cause
+    // long lists to squeeze their children at the bottom of the screen
+    // (This needs to be done *after* setAttribute)
+    panel.classList.remove('position-by-bottom');
+    if (options.placement === 'right' && panel.scrollHeight > panel.clientHeight ) {
+      panel.style.setProperty('--y', `${rect.y + rect.height}px`);
+      panel.classList.add('position-by-bottom');
+    }
   };
 
   anchor.addEventListener('click', () => {

--- a/plugins/in-app-menu/titlebar.css
+++ b/plugins/in-app-menu/titlebar.css
@@ -80,6 +80,11 @@ menu-panel[open="true"] {
   opacity: 1;
   transform: scale(1);
 }
+menu-panel.position-by-bottom {
+  top: unset;
+  bottom: calc(100vh - var(--y, 100%));
+  max-height: calc(var(--y, 0) - var(--menu-bar-height, 36px) - 16px);
+}
 
 menu-item {
   -webkit-app-region: none;


### PR DESCRIPTION
Previously, when using the `in-app-menu` plugin, menu children at the bottom of the screen would get squished, especially when there were multiple layers of children:
<details>
<summary> Show Image </summary>

![ytm_menu_very_squished](https://github.com/th-ch/youtube-music/assets/51007423/87ca7173-63b8-4769-8ef2-023674939630)

</details>

This fixes this by checking if a child menu can scroll (meaning it is squished), and instead positioning it by the bottom of the element:
<details>
<summary> Show Image </summary>

![ytm_menu_fixed](https://github.com/th-ch/youtube-music/assets/51007423/499228e0-2537-4882-846b-ee7c335f2849)

</details>

The `max-height` property is also adjusted to prevent the menu from going off of the screen.

---
The only potential caveat is that long child menus near the top of the screen will actually have their size reduced, but I don't think this is a real problem as none of the menus (that I know of) are like this:
<details>
<summary> Show Image </summary>

![image](https://github.com/th-ch/youtube-music/assets/51007423/13a8e1bd-25ab-45df-a349-d245177afa34)

</details>