### PR TITLE
Fix Library removed for Premium users

### DIFF
--- a/preload.ts
+++ b/preload.ts
@@ -187,7 +187,7 @@ function onApiLoaded() {
   // Remove upgrade button
   if (config.get('options.removeUpgradeButton')) {
     const styles = document.createElement('style');
-    styles.innerHTML = `ytmusic-guide-section-renderer #items ytmusic-guide-entry-renderer:last-child {
+    styles.innerHTML = `ytmusic-guide-section-renderer #items ytmusic-guide-entry-renderer:nth-child(4) {
       display: none;
     }`;
     document.head.appendChild(styles);


### PR DESCRIPTION
As by now, the code removes the last child of the YT's buttons sidebar. It's good for non-premium users but affects premium users, as it removes the "Library" button.

This small fix targets the 4th child (usually the Upgrade button location) instead of last child.

A bad move/practice, but does its job and remove the Upgrade button while not removing the Library one.