### PR TITLE
Fix downloader Korean filename on Windows, etc.

### DIFF
--- a/plugins/downloader/back.ts
+++ b/plugins/downloader/back.ts
@@ -199,10 +199,13 @@ async function downloadSongUnsafe(
     presetSetting = presets[preset];
   }
 
-  const filename = filenamify(`${name}.${presetSetting?.extension ?? 'mp3'}`, {
+  let filename = filenamify(`${name}.${presetSetting?.extension ?? 'mp3'}`, {
     replacement: '_',
     maxLength: 255,
   });
+  if (!is.macOS()) {
+    filename = filename.normalize('NFC');
+  }
   const filePath = join(dir, filename);
 
   if (config.get('skipExisting') && existsSync(filePath)) {

--- a/readme.md
+++ b/readme.md
@@ -178,7 +178,7 @@ Some predefined themes are available in https://github.com/kerichdev/themes-for-
 ```bash
 git clone https://github.com/th-ch/youtube-music
 cd youtube-music
-npm
+npm ci
 npm run start
 ```
 


### PR DESCRIPTION
## Abstract
There is various unicode normalize in UTF-8. [#See here in Korean example](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/String/normalize#%ED%95%9C%EA%B8%80%EC%97%90_normalize_%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0) Windows uses `NFC`, but MacOS uses `NFD`. If download music which includes Korean in title, file name in Windows is seemed as below.
![image](https://github.com/th-ch/youtube-music/assets/20399222/d98e7d85-812c-41ae-8ac2-990c6ed3e807)
This PR resolves ubove problem. See below.
![image](https://github.com/th-ch/youtube-music/assets/20399222/3c3d115b-76bb-4d6e-8705-d4d4a95ab552)


## Changes
`filenamify` returns always file name normalized `NFD`, not depending on OS. There is not standard for seperating OS in Javascript Runtime Environment, therefore I think it is not good idea for modify `filenamify`. This PR check current OS, then if not MacOS, normalize file name to `NFC`.