### PR TITLE
Fix mpris `player.loopStatus`

### DIFF
--- a/plugins/shortcuts/mpris.ts
+++ b/plugins/shortcuts/mpris.ts
@@ -51,11 +51,11 @@ function registerMPRIS(win: BrowserWindow) {
           break;
         }
         case 'ONE': {
-          player.loopStatus = mpris.LOOP_STATUS_PLAYLIST;
+          player.loopStatus = mpris.LOOP_STATUS_TRACK;
           break;
         }
         case 'ALL': {
-          player.loopStatus = mpris.LOOP_STATUS_TRACK;
+          player.loopStatus = mpris.LOOP_STATUS_PLAYLIST;
           // No default
           break;
         }


### PR DESCRIPTION
`ONE` and `ALL` were switched up.