### PR TITLE
fix: add workaround for `podcast` type video

### DIFF
--- a/src/providers/song-info-front.ts
+++ b/src/providers/song-info-front.ts
@@ -137,6 +137,12 @@ export default () => {
       data.videoDetails.album = videoData?.Hd?.playerOverlays?.playerOverlayRenderer?.browserMediaSession?.browserMediaSessionRenderer?.album.runs?.at(0)?.text;
       data.videoDetails.elapsedSeconds = 0;
       data.videoDetails.isPaused = false;
+
+      // HACK: This is a workaround for "podcast" type video. GREAT JOB GOOGLE.
+      if (data.playabilityStatus.transportControlsConfig) {
+        data.videoDetails.author = data.microformat.microformatDataRenderer.pageOwnerDetails.name;
+      }
+
       ipcRenderer.send('video-src-changed', data);
     }
   }, { once: true, passive: true });

--- a/src/types/get-player-response.ts
+++ b/src/types/get-player-response.ts
@@ -217,6 +217,17 @@ export interface PlayabilityStatus {
   audioOnlyPlayability: AudioOnlyPlayability;
   miniplayer: Miniplayer;
   contextParams: string;
+  transportControlsConfig?: TransportControlsConfig;
+}
+
+type ReplaceDefaultType = {
+  replaceDefault: boolean,
+};
+
+export interface TransportControlsConfig {
+  seekForwardStatus: ReplaceDefaultType;
+  seekBackwardStatus: ReplaceDefaultType;
+  playbackRateStatus: ReplaceDefaultType;
 }
 
 export interface AudioOnlyPlayability {


### PR DESCRIPTION
- `Podcast` type videos don't have the correct `author` data.
	- example track: https://music.youtube.com/watch?v=QcpjV43ALCA&si=CfbqZTUX_Jd44yLR
		- Except data: `*Luna`
		- Actual data: `♬Original Song`
		![image](https://github.com/th-ch/youtube-music/assets/16558115/a2467e9c-3b92-4b72-8a54-d4a4312421e9)
		`playerResponse.videoDetails.author`
		![image](https://github.com/th-ch/youtube-music/assets/16558115/b2823155-aa5f-45cf-8e73-b463be212339)
		But in YTM, it looks normal.
	- example track 2: https://music.youtube.com/watch?v=HK8fmW_laqo&si=peCP5OACiM-rvrRm
		- Except data: `つぐ`
		- Actual data: `tug`
- So I decided to use a trick to get the correct data.