### PR TITLE
fix: Only apply scale factor on Windows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -299,7 +299,7 @@ async function createMainWindow() {
     const { x: windowX, y: windowY } = windowPosition;
     const winSize = win.getSize();
     const display = screen.getDisplayNearestPoint(windowPosition);
-    const scaleFactor = display.scaleFactor;
+    const scaleFactor = is.windows() ? display.scaleFactor: 1;
 
     const scaledWidth = Math.floor(windowSize.width / scaleFactor);
     const scaledHeight = Math.floor(windowSize.height / scaleFactor);


### PR DESCRIPTION
This PR fixes https://github.com/th-ch/youtube-music/issues/1563 - on MacOS, the scale factor is 2, which leads to the unwanted effect of dividing the window size by 2 when starting the app. Since the original bug was for Windows, applying the scale factor is set for Windows only.