### PR TITLE
Support disabling scrobbling for non-music content

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ winget install th-ch.YouTubeMusic
   > (see [this post](https://github.com/th-ch/youtube-music/issues/410#issuecomment-952060709) if you have problem
   accessing the menu after enabling this plugin and hide-menu option)
 
-- [**Last.fm**](https://www.last.fm/): Scrobbles support
+- **Scrobbler**: Adds scrobbling support for [Last.fm](https://www.last.fm/) and [ListenBrainz](https://listenbrainz.org/)
 
 - **Lumia Stream**: Adds [Lumia Stream](https://lumiastream.com/) support
 

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -32,6 +32,7 @@ export interface DefaultConfig {
     proxy: string;
     startingPage: string;
     overrideUserAgent: boolean;
+    usePodcastParticipantAsArtist: boolean;
     themes: string[];
   };
   plugins: Record<string, unknown>;
@@ -66,6 +67,7 @@ const defaultConfig: DefaultConfig = {
     proxy: '',
     startingPage: '',
     overrideUserAgent: false,
+    usePodcastParticipantAsArtist: false,
     themes: [],
   },
   'plugins': {},

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -572,6 +572,7 @@
     "scrobbler": {
       "description": "Add scrobbling support (etc. last.fm, Listenbrainz)",
       "menu": {
+        "scrobble-other-media": "Scrobble other media",
         "lastfm": {
           "api-settings": "Last.fm API Settings"
         },

--- a/src/plugins/scrobbler/index.ts
+++ b/src/plugins/scrobbler/index.ts
@@ -6,6 +6,12 @@ import { backend } from './main';
 
 export interface ScrobblerPluginConfig {
   enabled: boolean,
+  /**
+    * Attempt to scrobble other video types (e.g. Podcasts, normal YouTube videos)
+    *
+    * @default false
+    */
+  scrobble_other_media: boolean,
   scrobblers: {
     lastfm: {
       /**
@@ -64,6 +70,7 @@ export interface ScrobblerPluginConfig {
 
 export const defaultConfig: ScrobblerPluginConfig = {
   enabled: false,
+  scrobble_other_media: false,
   scrobblers: {
     lastfm: {
       enabled: false,

--- a/src/plugins/scrobbler/index.ts
+++ b/src/plugins/scrobbler/index.ts
@@ -9,7 +9,7 @@ export interface ScrobblerPluginConfig {
   /**
     * Attempt to scrobble other video types (e.g. Podcasts, normal YouTube videos)
     *
-    * @default false
+    * @default true
     */
   scrobble_other_media: boolean,
   scrobblers: {
@@ -70,7 +70,7 @@ export interface ScrobblerPluginConfig {
 
 export const defaultConfig: ScrobblerPluginConfig = {
   enabled: false,
-  scrobble_other_media: false,
+  scrobble_other_media: true,
   scrobblers: {
     lastfm: {
       enabled: false,

--- a/src/plugins/scrobbler/main.ts
+++ b/src/plugins/scrobbler/main.ts
@@ -51,6 +51,11 @@ export const backend = createBackend<{
       clearTimeout(scrobbleTimer);
       if (!songInfo.isPaused) {
         const configNonnull = this.config!;
+        // Scrobblers normally have no trouble working with official music videos
+        if (!configNonnull.scrobble_other_media && (songInfo.mediaType !== 'AUDIO' && songInfo.mediaType !== 'ORIGINAL_MUSIC_VIDEO')) {
+          return;
+        }
+
         // Scrobble when the song is halfway through, or has passed the 4-minute mark
         const scrobbleTime = Math.min(Math.ceil(songInfo.songDuration / 2), 4 * 60);
         if (scrobbleTime > (songInfo.elapsedSeconds ?? 0)) {

--- a/src/plugins/scrobbler/menu.ts
+++ b/src/plugins/scrobbler/menu.ts
@@ -80,6 +80,15 @@ export const onMenu = async ({
 
   return [
     {
+      label: t('plugins.scrobbler.menu.scrobble-other-media'),
+      type: 'checkbox',
+      checked: Boolean(config.scrobble_other_media),
+      click(item) {
+        config.scrobble_other_media = item.checked;
+        setConfig(config);
+      },
+    },
+    {
       label: 'Last.fm',
       submenu: [
         {

--- a/src/providers/song-info-front.ts
+++ b/src/providers/song-info-front.ts
@@ -164,12 +164,6 @@ export default (api: YoutubePlayer) => {
     data.videoDetails.elapsedSeconds = 0;
     data.videoDetails.isPaused = false;
 
-    // HACK: This is a workaround for "podcast" type video. GREAT JOB GOOGLE.
-    if (data.playabilityStatus.transportControlsConfig) {
-      data.videoDetails.author =
-        data.microformat.microformatDataRenderer.pageOwnerDetails.name;
-    }
-
     window.ipcRenderer.send('ytmd:video-src-changed', data);
   }
 };


### PR DESCRIPTION
Also added the plugin description to the README.

There's now a "Scrobble other media" config option to toggle scrobbling of non-audio/non-music video content.

closes #1648 
closes #1646