### PR TITLE
feat(album-color-theme): support album color theme in all pages

### DIFF
--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -212,7 +212,15 @@
     },
     "album-color-theme": {
       "description": "Applies a dynamic theme and visual effects based on the album color palette",
-      "name": "Album Color Theme"
+      "name": "Album Color Theme",
+      "menu": {
+        "color-mix-ratio": {
+          "label": "Color mix ratio",
+          "submenu": {
+            "percent": "{{ratio}}%"
+          }
+        }
+      }
     },
     "ambient-mode": {
       "description": "Applies a lighting effect by casting gentle colors from the video, into your screen’s background",

--- a/src/plugins/album-color-theme/index.ts
+++ b/src/plugins/album-color-theme/index.ts
@@ -24,13 +24,13 @@ export default createPlugin<
     sidebarSmall: HTMLElement | null;
     ytmusicAppLayout: HTMLElement | null;
 
-    getColor(key: string, alpha?: number): string;
+    getMixedColor(color: string, key: string, ratio?: number, alpha?: number): string;
     updateColor(): void;
   }
 >({
   name: () => t('plugins.album-color-theme.name'),
   description: () => t('plugins.album-color-theme.description'),
-  restartNeeded: true,
+  restartNeeded: false,
   config: {
     enabled: false,
   },
@@ -97,28 +97,52 @@ export default createPlugin<
         this.updateColor();
       });
     },
-    getColor(key: string, alpha = 1) {
-      return `rgba(var(${key}), ${alpha})`;
+    getMixedColor(color: string, key: string, ratio = 0.2, alpha = 1) {
+      const keyColor = `rgba(var(${key}), ${alpha})`;
+      return `color-mix(in srgb, ${color} ${Math.round((1 - ratio) * 100)}%, ${keyColor} ${Math.round(ratio * 100)}%)`;
     },
     updateColor() {
-      const change = (element: HTMLElement | null, color: string) => {
-        if (element) {
-          element.style.backgroundColor = color;
-        }
+      const variableMap = {
+        '--ytmusic-color-black1': '#212121',
+        '--ytmusic-color-black2': '#181818',
+        '--ytmusic-color-black3': '#030303',
+        '--ytmusic-color-black4': '#030303',
+        '--ytmusic-color-blackpure': '#000',
+        '--dark-theme-background-color': '#212121',
+        '--yt-spec-base-background': '#0f0f0f',
+        '--yt-spec-raised-background': '#212121',
+        '--yt-spec-menu-background': '#282828',
+        '--yt-spec-static-brand-black': '#212121',
+        '--yt-spec-static-overlay-background-solid': '#000',
+        '--yt-spec-static-overlay-background-heavy': 'rgba(0,0,0,0.8)',
+        '--yt-spec-static-overlay-background-medium': 'rgba(0,0,0,0.6)',
+        '--yt-spec-static-overlay-background-medium-light': 'rgba(0,0,0,0.3)',
+        '--yt-spec-static-overlay-background-light': 'rgba(0,0,0,0.1)',
+        '--yt-spec-general-background-a': '#181818',
+        '--yt-spec-general-background-b': '#0f0f0f',
+        '--yt-spec-general-background-c': '#030303',
+        '--yt-spec-snackbar-background': '#030303',
+        '--yt-spec-filled-button-text': '#030303',
+        '--yt-spec-black-1': '#282828',
+        '--yt-spec-black-2': '#1f1f1f',
+        '--yt-spec-black-3': '#161616',
+        '--yt-spec-black-4': '#0d0d0d',
+        '--yt-spec-black-pure': '#000',
+        '--yt-spec-black-pure-alpha-5': 'rgba(0,0,0,0.05)',
+        '--yt-spec-black-pure-alpha-10': 'rgba(0,0,0,0.1)',
+        '--yt-spec-black-pure-alpha-15': 'rgba(0,0,0,0.15)',
+        '--yt-spec-black-pure-alpha-30': 'rgba(0,0,0,0.3)',
+        '--yt-spec-black-pure-alpha-60': 'rgba(0,0,0,0.6)',
+        '--yt-spec-black-pure-alpha-80': 'rgba(0,0,0,0.8)',
+        '--yt-spec-black-1-alpha-98': 'rgba(40,40,40,0.98)',
+        '--yt-spec-black-1-alpha-95': 'rgba(40,40,40,0.95)',
       };
+      Object.entries(variableMap).map(([variable, color]) => {
+        document.documentElement.style.setProperty(variable, this.getMixedColor(color, COLOR_KEY), 'important');
+      });
 
-      change(this.playerPage, this.getColor(DARK_COLOR_KEY));
-      change(this.navBarBackground, this.getColor(COLOR_KEY));
-      change(this.ytmusicPlayerBar, this.getColor(COLOR_KEY));
-      change(this.playerBarBackground, this.getColor(COLOR_KEY));
-      change(this.sidebarBig, this.getColor(COLOR_KEY));
-
-      if (this.ytmusicAppLayout?.hasAttribute('player-page-open')) {
-        change(this.sidebarSmall, this.getColor(DARK_COLOR_KEY));
-      }
-
-      const ytRightClickList = document.querySelector<HTMLElement>('tp-yt-paper-listbox');
-      change(ytRightClickList, this.getColor(COLOR_KEY));
+      document.body.style.setProperty('background', this.getMixedColor('#030303', COLOR_KEY), 'important');
+      document.body.style.setProperty('--ytmusic-background', `linear-gradient(var(--ytmusic-general-background-a), var(--ytmusic-general-background-c))`, 'important');
     },
   },
 });

--- a/src/plugins/album-color-theme/style.css
+++ b/src/plugins/album-color-theme/style.css
@@ -65,3 +65,11 @@ ytmusic-player-bar {
 .volume-slider.ytmusic-player-bar, .expand-volume-slider.ytmusic-player-bar {
   --paper-slider-container-color: rgba(255, 255, 255, 0.5) !important;
 }
+
+/* fix background image */
+ytmusic-fullbleed-thumbnail-renderer img {
+  mask: linear-gradient(to bottom, #000 0%, #000 50%, transparent 100%);
+}
+.background-gradient.style-scope {
+  background: var(--ytmusic-background) !important;
+}

--- a/src/plugins/album-color-theme/style.css
+++ b/src/plugins/album-color-theme/style.css
@@ -73,3 +73,9 @@ ytmusic-fullbleed-thumbnail-renderer img {
 .background-gradient.style-scope {
   background: var(--ytmusic-background) !important;
 }
+ytmusic-browse-response[has-background]:not([disable-gradient]) .background-gradient.ytmusic-browse-response {
+  background: unset !important;
+}
+#background.immersive-background.style-scope.ytmusic-browse-response {
+  opacity: 0.6;
+}

--- a/src/plugins/blur-nav-bar/style.css
+++ b/src/plugins/blur-nav-bar/style.css
@@ -1,8 +1,16 @@
 #nav-bar-background,
-#header.ytmusic-item-section-renderer,
-ytmusic-tabs {
+#header.ytmusic-item-section-renderer {
   background: rgba(0, 0, 0, 0.3) !important;
   backdrop-filter: blur(8px) !important;
+}
+
+ytmusic-tabs {
+  top: calc(var(--ytmusic-nav-bar-height) + var(--menu-bar-height, 36px));
+  backdrop-filter: blur(8px) !important;
+}
+
+ytmusic-tabs.stuck {
+  background: rgba(0, 0, 0, 0.3) !important;
 }
 
 #nav-bar-divider {

--- a/src/plugins/in-app-menu/titlebar.css
+++ b/src/plugins/in-app-menu/titlebar.css
@@ -1,5 +1,5 @@
 :root {
-  --titlebar-background-color: #030303;
+  --titlebar-background-color: var(--ytmusic-color-black3);
   --menu-bar-height: 32px;
 }
 


### PR DESCRIPTION
# Summary
![image](https://github.com/th-ch/youtube-music/assets/13764936/47431a91-2894-4913-a863-f52f2cfcbfe4)
![image](https://github.com/th-ch/youtube-music/assets/13764936/c24f2c23-f752-408a-9149-20a8f635935a)
![image](https://github.com/th-ch/youtube-music/assets/13764936/66583192-51bc-4d90-ba01-5bfa4948a85a)

- Using album color in all pages

# Description
- It overrides predefined ytmusic variable
- fix blur-nav-bar height issue
    ![image](https://github.com/th-ch/youtube-music/assets/13764936/0429d788-5e6a-4a1c-9125-f32b7ea653d2)
    ![image](https://github.com/th-ch/youtube-music/assets/13764936/c7555793-0df0-4f03-b1d7-564e23ee75be)
- change in-app-menu plugin style

# Notes
- resolve #1677