### PR TITLE
Fixes #1617 menu icon on the top left of title bar

### DIFF
--- a/src/plugins/in-app-menu/renderer.ts
+++ b/src/plugins/in-app-menu/renderer.ts
@@ -71,8 +71,6 @@ export const onRendererLoad = async ({
   if (!isMacOS) titleBar.appendChild(logo);
   document.body.appendChild(titleBar);
 
-  titleBar.appendChild(logo);
-
   const addWindowControls = async () => {
     // Create window control buttons
     const minimizeButton = document.createElement('button');


### PR DESCRIPTION
**Fixed  #1617 for macOS:**

Weird menu icon on the top left of menu bar was resulted from the failure to exclude _titleBar.appendChild(logo)_ for MacOS.

**From**

<img width="1028" alt="Screenshot 2024-01-27 at 8 11 23 PM" src="https://github.com/th-ch/youtube-music/assets/133816965/447c732b-649c-4ad2-b6c8-249fe3eb0d5d">


**To**

<img width="1028" alt="Screenshot 2024-01-27 at 8 20 34 PM" src="https://github.com/th-ch/youtube-music/assets/133816965/7797c405-a149-4c90-8360-cf5f891714d4">
