### PR TITLE
fix(style): fixed image/video alignment when toggle is active

### DIFF
--- a/src/youtube-music.css
+++ b/src/youtube-music.css
@@ -21,7 +21,6 @@ ytmusic-nav-bar > .right-content > * {
   -webkit-app-region: no-drag;
 }
 
-
 iron-icon,
 ytmusic-pivot-bar-item-renderer,
 .tab-title,
@@ -65,7 +64,13 @@ ytmusic-nav-bar > div.left-content > a > picture > img {
 tp-yt-paper-item.ytmusic-guide-entry-renderer::before {
   border-radius: 8px !important;
 }
-/** apply fix when #av-id is exist */
-ytmusic-player-page:not([video-mode]):not([player-fullscreened]) #av-id ~ #player.ytmusic-player-page {
-  margin-top: calc(var(--ytmusic-player-page-vertical-padding) / 2 * -1) !important;
+
+#av-id {
+  padding-bottom: 0;
+}
+
+#av-id ~ #player.ytmusic-player-page {
+  margin-top: auto !important;
+  margin-bottom: auto !important;
+  max-height: calc(100% - (var(--ytmusic-player-page-vertical-padding) * 2));
 }


### PR DESCRIPTION
This should fix the vertical alignment of the album cover, described in this [Issue](https://github.com/th-ch/youtube-music/issues/1781).

- I removed the previous styling (margin-top) from commit [f8e55f95](https://github.com/th-ch/youtube-music/commit/f8e55f95df875dd7233801f7fe961522b6cde7df) which gets it to the same state as the official yt-music player.
- I then removed the padding from the toggle and used a max-height on the player in order to make sure there will always be some spacing above and below the album cover
  - This comes with a slight caveat, namely that the album cover might get cropped with object-fit: cover on some windows sizes, which is not fixable without reworking a lot of the official yt client styles/layout. I will leave this up to you guys to decide which is the lesser evil.