### PR TITLE
fix(mpris): use global regex to replace minus in the video ID

### DIFF
--- a/src/plugins/shortcuts/mpris.ts
+++ b/src/plugins/shortcuts/mpris.ts
@@ -99,7 +99,7 @@ function registerMPRIS(win: BrowserWindow) {
     const microToSec = (n: number) => Math.round(Number(n) / 1e6);
 
     const correctId = (videoId: string) => {
-      return videoId.replace('-', '_MINUS_');
+      return videoId.replace(/-/g, '_MINUS_');
     };
 
     const seekTo = (event: Position) => {


### PR DESCRIPTION
Fixes #1962 

This method should replace ALL minus `-` with `_MINUS_`, but it only replaces the first match

https://github.com/th-ch/youtube-music/blob/eff2f550c698058dd66d254a7b052330e11f0229/src/plugins/shortcuts/mpris.ts#L101-L103

The solution implemented here uses the global search flag `replace(/-/g, '_MINUS_')`, but these other options are also possible:

```js
replaceAll('-', '_MINUS_')
replaceAll(/-/g, '_MINUS_') // a bit redundant, but works
```
![image](https://github.com/th-ch/youtube-music/assets/121690516/9fd1e577-b41f-4562-83be-84652138eaee)