### PR TITLE
fix: add AdGuard as blocklist sources

### DIFF
--- a/src/plugins/adblocker/blocker.ts
+++ b/src/plugins/adblocker/blocker.ts
@@ -15,6 +15,8 @@ const SOURCES = [
   'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters-2023.txt',
   // Fanboy Annoyances
   'https://secure.fanboy.co.nz/fanboy-annoyance_ubo.txt',
+  // AdGuard
+  'https://filters.adtidy.org/extension/ublock/filters/122_optimized.txt',
 ];
 
 let blocker: ElectronBlocker | undefined;


### PR DESCRIPTION
Added another blocklist source provided by Trixarian in #1817. This will block ads that many users have been experiencing in the application without requiring them to add the source to the custom blocklist themselves.

If merged, this will issue #1817 should be ready to close.

Thank you all for creating this amazing tool :D