### PR TITLE
Prevents player to start with invalid MPRIS interface

### DIFF
--- a/src/plugins/shortcuts/main.ts
+++ b/src/plugins/shortcuts/main.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, globalShortcut } from 'electron';
+import { BrowserWindow, ipcMain, globalShortcut } from 'electron';
 import is from 'electron-is';
 import { register as registerElectronLocalShortcut } from 'electron-localshortcut';
 
@@ -48,7 +48,9 @@ export const onMainLoad = async ({
   _registerLocalShortcut(window, 'CommandOrControl+L', search);
 
   if (is.linux()) {
-    registerMPRIS(window);
+    ipcMain.once('ytmd:video-src-changed', (_) => {
+      registerMPRIS(window);
+    });
   }
 
   const { global, local } = config;


### PR DESCRIPTION
Instead of registering MPRIS interface immediately after startup we do it once when ytmd:video-src-changed is triggered. Also works when autoplay song at startup is selected. Fixes #1985. Since there is no stop present for this player (only play/pause) we don't have to care about unregistering once the player is registered