### PR TITLE
Fix substract `margin-top` in fullscreen mode

### DIFF
--- a/src/youtube-music.css
+++ b/src/youtube-music.css
@@ -78,5 +78,5 @@ tp-yt-paper-item.ytmusic-guide-entry-renderer::before {
 }
 
 ytmusic-player[player-ui-state=FULLSCREEN] {
-  top: calc(var(--menu-bar-height, 32px) * -1) !important;
+  margin-top: calc(var(--menu-bar-height, 32px) * -1) !important;
 }


### PR DESCRIPTION
Detailed information about the bug had been mentioned in #2013.
Basically, the css should subtract the `margin-top` size instead `top`.


Fix #2013 