### PR TITLE
Enable arm64 for deb and rpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ latest version.
 Install the [`youtube-music-bin`](https://aur.archlinux.org/packages/youtube-music-bin) package from the AUR. For AUR installation instructions, take a look at
 this [wiki page](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages).
 
-### MacOS
+### macOS
 
 You can install the app using Homebrew (see the [cask definition](https://github.com/th-ch/homebrew-youtube-music)):
 
@@ -365,8 +365,11 @@ export default createPlugin({
 4. Run `pnpm build:OS`
 
 - `pnpm dist:win` - Windows
-- `pnpm dist:linux` - Linux
-- `pnpm dist:mac` - MacOS
+- `pnpm dist:linux` - Linux (amd64)
+- `pnpm dist:linux:deb-arm64` - Linux (arm64 for Debian)
+- `pnpm dist:linux:rpm-arm64` - Linux (arm64 for Fedora)
+- `pnpm dist:mac` - macOS (amd64)
+- `pnpm dist:mac:arm64` - macOS (arm64)
 
 Builds the app for macOS, Linux, and Windows,
 using [electron-builder](https://github.com/electron-userland/electron-builder).

--- a/package.json
+++ b/package.json
@@ -107,6 +107,8 @@
     "clean": "del-cli dist && del-cli pack && del-cli .vite-inspect",
     "dist": "pnpm clean && pnpm build && pnpm electron-builder --win --mac --linux -p never",
     "dist:linux": "pnpm clean && pnpm build && pnpm electron-builder --linux -p never",
+    "dist:linux:deb-arm64": "pnpm clean && pnpm build && pnpm electron-builder --linux deb:arm64 -p never",
+    "dist:linux:rpm-arm64": "pnpm clean && pnpm build && pnpm electron-builder --linux rpm:arm64 -p never",
     "dist:mac": "pnpm clean && pnpm build && pnpm electron-builder --mac dmg:x64 -p never",
     "dist:mac:arm64": "pnpm clean && pnpm build && pnpm electron-builder --mac dmg:arm64 -p never",
     "dist:win": "pnpm clean && pnpm build && pnpm electron-builder --win -p never",


### PR DESCRIPTION
This updates the README for the new macOS arm64 option as well as adds the option to build arm64 packages for deb and rpm distros.