### PR TITLE
Set activity to "Listening" instead of "Playing"

### DIFF
--- a/src/plugins/discord/main.ts
+++ b/src/plugins/discord/main.ts
@@ -180,12 +180,12 @@ export const backend = createBackend<
     }
 
     const activityInfo: SetActivity = {
-      type: ActivityType.Listening,
       details: songInfo.title,
       state: songInfo.artist,
       largeImageKey: songInfo.imageSrc ?? '',
       largeImageText: songInfo.album ?? '',
       buttons,
+      type: ActivityType.Listening,
     };
 
     if (songInfo.isPaused) {

--- a/src/plugins/discord/main.ts
+++ b/src/plugins/discord/main.ts
@@ -180,6 +180,7 @@ export const backend = createBackend<
     }
 
     const activityInfo: SetActivity = {
+      type: ActivityType.Listening,
       details: songInfo.title,
       state: songInfo.artist,
       largeImageKey: songInfo.imageSrc ?? '',


### PR DESCRIPTION
It is a simple change but makes it 100x better when seeing my status on Discord. This is indeed possible as seen in [the code for the fork of discord.js used in this repository](https://github.com/xhayper/discord-rpc/blob/6683ce4abb75867ddde1b8ce31657de564f5ed0a/src/structures/ClientUser.ts#L75)