### PR TITLE
fix: disable multi-plane format for software video

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,9 +100,18 @@ if (config.get('options.disableHardwareAcceleration')) {
   app.disableHardwareAcceleration();
 }
 
-if (is.linux() && config.plugins.isEnabled('shortcuts')) {
+if (is.linux()) {
+  const disabledFeatures = [
+    // Workaround for issue #2248
+    'UseMultiPlaneFormatForSoftwareVideo',
+  ];
+
   // Stops chromium from launching its own MPRIS service
-  app.commandLine.appendSwitch('disable-features', 'MediaSessionService');
+  if (config.plugins.isEnabled('shortcuts')) {
+    disabledFeatures.push('MediaSessionService');
+  }
+
+  app.commandLine.appendSwitch('disable-features', disabledFeatures.join());
 }
 
 if (config.get('options.proxy')) {


### PR DESCRIPTION
Fixes #2248 

This disables `UseMultiPlaneFormatForSoftwareVideo` when using linux.

I don't know if we need to disable `UseMultiPlaneFormatForHardwareVideo` as well, I could not personally test it.

<details>
<summary>Image: after this change the error does not seem to occur</summary>
<img src="https://github.com/user-attachments/assets/c6de2984-d86e-4e47-bad7-1e925f381d00">
</details>
