### PR TITLE
fix: exclude build-id files from rpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,10 @@
     "rpm": {
       "depends": [
         "/usr/lib64/libuuid.so.1"
+      ],
+      "fpm": [
+        "--rpm-rpmbuild-define",
+        "_build_id_links none"
       ]
     },
     "snap": {


### PR DESCRIPTION
Closes: #2358 #1882

Adds additional arguments to fpm to prevent rpmbuild from adding .build-id links to the RPM package.

Based on this comment: https://github.com/jordansissel/fpm/issues/1503#issuecomment-404849150

Tested locally on Fedora 40. Confirmed `pack/builder-effective-config.yaml` contained the additional fpm arguments and extracted the RPM contents to confirm the `/usr/lib/.build-id` files were no longer present.