### PR TITLE
fix: hide native-controls on linux when in-app-menu is used

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ import { loadI18n, setLanguage, t } from '@/i18n';
 import ErrorHtmlAsset from '@assets/error.html?asset';
 
 import type { PluginConfig } from '@/types/plugins';
+import BrowserWindowConstructorOptions = Electron.BrowserWindowConstructorOptions;
 
 if (!is.macOS()) {
   delete allPlugins['touchbar'];
@@ -286,6 +287,23 @@ async function createMainWindow() {
     height: 32,
   };
 
+  const decorations: Partial<BrowserWindowConstructorOptions> = {
+    frame: !is.macOS() && !useInlineMenu,
+    titleBarOverlay: defaultTitleBarOverlayOptions,
+    titleBarStyle: useInlineMenu
+      ? 'hidden'
+      : is.macOS()
+        ? 'hiddenInset'
+        : 'default',
+    autoHideMenuBar: config.get('options.hideMenu'),
+  };
+
+  // Note: on linux, for some weird reason, having these extra properties with 'frame: false' does not work
+  if (is.linux() && useInlineMenu) {
+    delete decorations.titleBarOverlay;
+    delete decorations.titleBarStyle;
+  }
+
   const win = new BrowserWindow({
     icon,
     width: windowSize.width,
@@ -303,14 +321,7 @@ async function createMainWindow() {
             sandbox: false,
           }),
     },
-    frame: !is.macOS() && !useInlineMenu,
-    titleBarOverlay: defaultTitleBarOverlayOptions,
-    titleBarStyle: useInlineMenu
-      ? 'hidden'
-      : is.macOS()
-      ? 'hiddenInset'
-      : 'default',
-    autoHideMenuBar: config.get('options.hideMenu'),
+    ...decorations,
   });
   initHook(win);
   initTheme(win);


### PR DESCRIPTION
Closes: #2365

On linux, for some weird reason, having both `frame: false` and `titleBarStyle` as well as `titleBarOverlay` causes a mess.
This fix not only hides the ugly window controls (default GTK controls iirc), it also allows electron to use the system-wide theme for when the in-app-menu is disabled.

I haven't seen any obvious regression due to the changes I make in this PR, but just to be safe, I am asking anyone that reads this to test this PR locally and provide feedback.