### PR TITLE
fix: incorrect regex when

### DIFF
--- a/src/plugins/synced-lyrics/renderer/lyrics/fetch.ts
+++ b/src/plugins/synced-lyrics/renderer/lyrics/fetch.ts
@@ -126,8 +126,8 @@ export const getLyricsList = async (
     const { artist } = songData;
     const { artistName } = item;
 
-    const artists = artist.split(/&,/).map((i) => i.trim());
-    const itemArtists = artistName.split(/&,/).map((i) => i.trim());
+    const artists = artist.split(/[&,]/g).map((i) => i.trim());
+    const itemArtists = artistName.split(/[&,]/g).map((i) => i.trim());
 
     const permutations = [];
     for (const artistA of artists) {


### PR DESCRIPTION
Fixes the incorrect regex used to split a string in the form of `Name1 & Name2` or `Name1, Name2`.

Previously the regex was actually splitting on `Name1 &, Name2`...
