### PR TITLE
fix(synced-lyrics): LRCLIB returns 0 results if album is `undefined`

### DIFF
--- a/src/plugins/synced-lyrics/renderer/lyrics/fetch.ts
+++ b/src/plugins/synced-lyrics/renderer/lyrics/fetch.ts
@@ -78,9 +78,8 @@ export const getLyricsList = async (
     track_name: songData.title,
   });
 
-  query.set('album_name', songData.album!);
-  if (query.get('album_name') === 'undefined') {
-    query.delete('album_name');
+  if (songData.album) {
+    query.set('album_name', songData.album);
   }
 
   let url = `https://lrclib.net/api/search?${query.toString()}`;

--- a/src/plugins/synced-lyrics/renderer/lyrics/fetch.ts
+++ b/src/plugins/synced-lyrics/renderer/lyrics/fetch.ts
@@ -52,7 +52,7 @@ export const makeLyricsRequest = async (extractedSongInfo: SongInfo) => {
   const songData: Parameters<typeof getLyricsList>[0] = {
     title: `${extractedSongInfo.title}`,
     artist: `${extractedSongInfo.artist}`,
-    album: `${extractedSongInfo.album}`,
+    album: `${extractedSongInfo.album || ''}`,
     songDuration: extractedSongInfo.songDuration,
   };
 


### PR DESCRIPTION
If the song was in video form and/or didn't have an album associated with it, songData.album would be undefined which would be casted to string and end up in the URL params as `...&album=undefined` which returned 0 results from the API. Simply adding an OR (`||`) with an empty string fixed the issue