### PR TITLE
fix(renderer): fix force like buttons display logic

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -201,16 +201,16 @@ async function onApiLoaded() {
     'options.likeButtons',
   );
   if (likeButtonsOptions) {
-    const likeButtons: HTMLElement | null = document.querySelector(
-      'ytmusic-like-button-renderer',
-    );
-    if (likeButtons) {
-      likeButtons.style.display =
-        {
-          hide: 'none',
-          force: 'inherit',
-        }[likeButtonsOptions] || '';
-    }
+    const style = document.createElement('style');
+    style.textContent = `
+      ytmusic-player-bar[is-mweb-player-bar-modernization-enabled] .middle-controls-buttons.ytmusic-player-bar, #like-button-renderer {
+        display: ${likeButtonsOptions === 'hide' ? 'none' : 'inherit'} !important;
+      }
+      ytmusic-player-bar[is-mweb-player-bar-modernization-enabled] .middle-controls.ytmusic-player-bar {
+        justify-content: ${likeButtonsOptions === 'hide' ? 'flex-start' : 'space-between'} !important;
+      }`;
+
+    document.head.appendChild(style);
   }
 }
 


### PR DESCRIPTION
Fix the force show / hide like button in Visual Tweaks not work when screen width <= 935px and 615px.

Before & After:
![935](https://github.com/user-attachments/assets/c22ef4a0-093b-49c5-a8e1-8e473af951e9)
![615](https://github.com/user-attachments/assets/fd950a31-1295-4118-ab4a-36e2e44d417a)