### PR TITLE
fix: disable gpu memory buffer video frames

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,17 +131,18 @@ if (config.get('options.disableHardwareAcceleration')) {
 }
 
 if (is.linux()) {
-  const disabledFeatures = [
-    // Workaround for issue #2248
-    'UseMultiPlaneFormatForSoftwareVideo',
-  ];
+  // Workaround for issue #2248
+  if (
+    process.env.XDG_SESSION_TYPE === 'wayland' ||
+    process.env.WAYLAND_DISPLAY
+  ) {
+    app.commandLine.appendSwitch('disable-gpu-memory-buffer-video-frames');
+  }
 
   // Stops chromium from launching its own MPRIS service
   if (config.plugins.isEnabled('shortcuts')) {
-    disabledFeatures.push('MediaSessionService');
+    app.commandLine.appendSwitch('disable-features', 'MediaSessionService');
   }
-
-  app.commandLine.appendSwitch('disable-features', disabledFeatures.join());
 }
 
 if (config.get('options.proxy')) {


### PR DESCRIPTION
Fixes #2248 yet again

Somewhere between chromium 126 and 130 the flag `use-multi-plane-format-for-software-video` was removed.

Now the workaround flag is `disable-gpu-memory-buffer-video-frames`, as mentioned in this comment:
https://issuetracker.google.com/issues/331796411#comment13

I also added a small check to only add the flag if it's running on wayland 
```js
process.env.XDG_SESSION_TYPE === 'wayland' || process.env.WAYLAND_DISPLAY
```
(tested on Hyprland, but it should work on other compositors.)

<hr>

The issue seems to be fixed in chromium 131 with this commit:
https://chromium-review.googlesource.com/5873796

Once we get electron 34 (chromium 131) I'll test it again to see if the workaround is still needed