### PR TITLE
chore(docs): Specify full path to xattr for macOS, fixes #2583

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ brew install th-ch/youtube-music/youtube-music
 If you install the app manually and get an error "is damaged and can’t be opened." when launching the app, run the following in the Terminal:
 
 ```bash
-xattr -cr /Applications/YouTube\ Music.app
+/usr/bin/xattr -cr /Applications/YouTube\ Music.app
 ```
 
 ### Windows

--- a/docs/readme/README-es.md
+++ b/docs/readme/README-es.md
@@ -182,7 +182,7 @@ brew install th-ch/youtube-music/youtube-music
 Si instalas la aplicación manualmente y obtienes un error "está dañado y no se puede abrir" al iniciar la aplicación, ejecuta lo siguiente en la Terminal:
 
 ```bash
-xattr -cr /Applications/YouTube\ Music.app
+/usr/bin/xattr -cr /Applications/YouTube\ Music.app
 ```
 
 ### Windows

--- a/docs/readme/README-fr.md
+++ b/docs/readme/README-fr.md
@@ -185,7 +185,7 @@ brew install th-ch/youtube-music/youtube-music
 Si vous installez l'application manuellement et obtenez une erreur "est endommagé et ne peut pas être ouvert." lors du lancement de l'application, exécutez ce qui suit dans le Terminal :
 
 ```bash
-xattr -cr /Applications/YouTube\ Music.app
+/usr/bin/xattr -cr /Applications/YouTube\ Music.app
 ```
 
 ### Windows

--- a/docs/readme/README-is.md
+++ b/docs/readme/README-is.md
@@ -180,7 +180,7 @@ brew install th-ch/youtube-music/youtube-music
 Ef þú setur upp forritið handvirkt og færð villu "er skemmd og ekki er hægt að opna það," þegar þú ræsir forritið skaltu keyra eftirfarandi í flugstöðinni:
 
 ```bash
-xattr -cr /Applications/YouTube\ Music.app
+/usr/bin/xattr -cr /Applications/YouTube\ Music.app
 ```
 
 ### Windows

--- a/docs/readme/README-ko.md
+++ b/docs/readme/README-ko.md
@@ -147,7 +147,7 @@ brew install --cask https://raw.githubusercontent.com/th-ch/youtube-music/master
 (앱을 수동으로 설치하고) 앱을 실행할 때 `손상되었기 때문에 열 수 없습니다.`라는 오류가 발생하면 터미널에서 다음을 실행하세요:
 
 ```bash
-xattr -cr /Applications/YouTube\ Music.app
+/usr/bin/xattr -cr /Applications/YouTube\ Music.app
 ```
 
 ### Windows

--- a/docs/readme/README-ru.md
+++ b/docs/readme/README-ru.md
@@ -168,7 +168,7 @@ brew install th-ch/youtube-music/youtube-music
 Если вы устанавливаете приложение вручную и получаете ошибку "is damaged and can’t be opened.", запустите в терминале следующую команду:
 
 ```bash
-xattr -cr /Applications/YouTube\ Music.app
+/usr/bin/xattr -cr /Applications/YouTube\ Music.app
 ```
 
 ### Windows


### PR DESCRIPTION
On some Macs, Homebrew installs its own `xattr` which doesn't have the `-r` option. See #2583.

This PR just adds the full path to the system `xattr` in `README.md`, so the `-r` in the instructions doesn't cause a problem.

It's not clear to me whether or not the `-r` is required; this PR does not address that question, it just routes around it.

I have tested the instruction on my Mac which has the Homebrew `xattr`, and with the added path, it works.

I would assume this change is low risk; it's just to documentation, and the change points to a system command that should always be there. However, it's possible I'm missing corner cases that further testing and validation on more machines would uncover.