### PR TITLE
fix(ambient-mode): fix ambient-mode overlapping other elements

### DIFF
--- a/src/plugins/ambient-mode/style.css
+++ b/src/plugins/ambient-mode/style.css
@@ -34,3 +34,12 @@
   margin: 0 auto !important;
   overflow: visible;
 }
+
+/* Fix ambient mode overlapping other elements #2520 */
+.song-button.ytmusic-av-toggle, .video-button.ytmusic-av-toggle {
+  z-index: 1;
+  background-color: transparent;
+}
+#side-panel.side-panel.ytmusic-player-page {
+  z-index: 0;
+}

--- a/src/plugins/video-toggle/index.ts
+++ b/src/plugins/video-toggle/index.ts
@@ -129,6 +129,9 @@ export default createPlugin({
           document
             .querySelector('ytmusic-player')
             ?.setAttribute('has-av-switcher', '');
+          document
+            .querySelector('ytmusic-av-toggle')
+            ?.removeAttribute('toggle-disabled');
           return;
         }
 
@@ -139,6 +142,9 @@ export default createPlugin({
           document
             .querySelector('ytmusic-player')
             ?.removeAttribute('has-av-switcher');
+          document
+            .querySelector('ytmusic-av-toggle')
+            ?.setAttribute('toggle-disabled', '');
           return;
         }
       }


### PR DESCRIPTION
Fixes #2520

<hr>

**before**

![image](https://github.com/user-attachments/assets/488a5925-84bc-42ab-a6ab-110760f61f5a)

**after**

![image](https://github.com/user-attachments/assets/fc979025-afe5-4e94-a757-c89c38e2c881)

<hr>

More screenshots/explanation inside these spoiler tags:

<details><summary>audio-video toggle</summary>

```css
.song-button.ytmusic-av-toggle, .video-button.ytmusic-av-toggle {
  z-index: 1;
  background-color: transparent;
}
```

The z-index brings it above the canvas and the background-color does this:

||default (`#212121`)|background-color: transparent|
|-|-|-|
|ambient mode|![image](https://github.com/user-attachments/assets/43637990-4152-4b9f-b31f-109acdd4ab35)|![image](https://github.com/user-attachments/assets/0512696f-b265-40c1-a542-9e4eee8ab12c)|
|no ambient mode|![image](https://github.com/user-attachments/assets/e8323be3-94bc-42d9-a63a-91fbf8b025a3)|![image](https://github.com/user-attachments/assets/c7691a7d-a7e4-4b23-9d85-c91b99acf008)|

</details>

</details>

<details><summary>side panel</summary>

```css
#side-panel.side-panel.ytmusic-player-page {
  z-index: 0;
}
```

|before|after|
|-|-|
|![image](https://github.com/user-attachments/assets/75d99031-bc06-400a-8374-7bf7ab40984a)|![image](https://github.com/user-attachments/assets/0f0ae253-81c9-44dc-af31-fa8653ad35fa)|

OBS.: The other tabs, **lyrics** and **related**, are also fixed by this.

</details>

<details><summary>toggle-disabled</summary>

the av toggle has a "toggle-disabled" attribute which makes it look faded/disabled, as the name suggests, so I removed it.

|WITH toggle-disabled|NO toggle-disabled|
|-|-|
|![image](https://github.com/user-attachments/assets/a8a7894f-9032-49e0-8496-8f00b2399fd0)|![image](https://github.com/user-attachments/assets/c7691a7d-a7e4-4b23-9d85-c91b99acf008)|

I don't know how this attribute is actually used by youtube in the official web version (I don't have premium to test).
</details>