### PR TITLE
fix(discord): Fix Album Art failing on Discord RPC

### DIFF
--- a/src/providers/song-info.ts
+++ b/src/providers/song-info.ts
@@ -140,7 +140,7 @@ const handleData = async (
     }
 
     const thumbnails = videoDetails.thumbnail?.thumbnails;
-    songInfo.imageSrc = thumbnails.at(-1)?.url.split('?')[0];
+    songInfo.imageSrc = thumbnails.at(-1)?.url;
     if (songInfo.imageSrc) songInfo.image = await getImage(songInfo.imageSrc);
 
     win.webContents.send('ytmd:update-song-info', songInfo);


### PR DESCRIPTION
Fixes the album art for uploaded tracks failing on Discord and appearing as a ? block or a ripped image paper.

Removes a `.split` that removes all query parameters from the album art links ( removing the query parameter `?sqp`, necessary to authenticate the image url ) from the songInfo data handler. Unsure why this was added, if this breaks something somewhere else due to these query parameters being necessary to be removed, I would recommend this type of split is done there instead of making it completely inaccessible here.

Closes #2247 !

![image](https://github.com/user-attachments/assets/a340831e-0692-4d5f-9cca-d2a302b2c0c2)

![image](https://github.com/user-attachments/assets/95cc76dc-9507-4afb-8765-31273d335d6e)
