### PR TITLE
fix: Laggy scrolling behaviour in large playlists

### DIFF
--- a/src/plugins/in-app-menu/titlebar.css
+++ b/src/plugins/in-app-menu/titlebar.css
@@ -5,9 +5,12 @@
 
 /* youtube-music style */
 ytmusic-app-layout {
-  overflow: scroll;
+  overflow: auto scroll;
   height: calc(100vh - var(--menu-bar-height, 36px));
   margin-top: var(--menu-bar-height, 36px) !important;
+
+  /* fixes laggy list scrolling in large playlists */
+  backface-visibility: hidden;
 }
 ytmusic-app-layout#layout {
   --ytmusic-nav-bar-offset: 0px;
@@ -71,4 +74,9 @@ ytmusic-app-layout ytmusic-player-page[is-mweb-modernization-enabled] .side-pane
 /* ytm-bugs: see https://github.com/th-ch/youtube-music/issues/1737 */
 html {
   scrollbar-color: unset;
+}
+
+/* fixes scrollbar lagging behind in large playlists */
+ytmusic-browse-response .ytmusic-responsive-list-item-renderer {
+  will-change: transform;
 }


### PR DESCRIPTION
This commit aims to fix the following issues when the `in-app-menu` plugin was enabled:
* A small white square that would form when no song was playing/queued in the bottom right of the screen, just below the scrollbar.
* Laggy playlist scrolling that was noticeable when there were >30 songs.
* Scrollbar lagging behind in playlists where there were  >30 songs.


Fixes #2266 and most of the tagged issues in there. Would also buy some time until somebody commits to implementing #2533 - making the scrolling and navigation bareable in the meantime.