### PR TITLE
fix: tab misalignment

### DIFF
--- a/src/plugins/blur-nav-bar/style.css
+++ b/src/plugins/blur-nav-bar/style.css
@@ -5,7 +5,6 @@
 }
 
 ytmusic-tabs {
-  top: calc(var(--ytmusic-nav-bar-height) + var(--menu-bar-height, 36px));
   backdrop-filter: blur(8px) !important;
 }
 


### PR DESCRIPTION
Fixes the tab misalignment caused by the `blur-nav-bar` plugin.
Let YouTube Music handle its own top alignment, since --menu-bar-height isn’t a concern right now. This way, the plugin focuses solely on applying the background color and blur without interfering with alignment (as it should, if you ask me).

Before:
![Screenshot 2024-12-14 031109](https://github.com/user-attachments/assets/05991f2d-8ef5-4cb0-b516-f6e7ccf7c89b)

After:
![Screenshot 2024-12-14 030934](https://github.com/user-attachments/assets/9182b8a8-53f6-4e76-abfd-6433381ae7eb)