### PR TITLE
fix: discord rich presence connection status

### DIFF
--- a/src/plugins/discord/main.ts
+++ b/src/plugins/discord/main.ts
@@ -110,8 +110,7 @@ export const clear = () => {
 };
 
 export const registerRefresh = (cb: () => void) => refreshCallbacks.push(cb);
-export const isConnected = () =>
-  info.rpc !== null && info.rpc?.isConnected === true;
+export const isConnected = () => info.rpc?.isConnected;
 
 export const backend = createBackend<
   {

--- a/src/plugins/discord/main.ts
+++ b/src/plugins/discord/main.ts
@@ -110,7 +110,8 @@ export const clear = () => {
 };
 
 export const registerRefresh = (cb: () => void) => refreshCallbacks.push(cb);
-export const isConnected = () => info.rpc !== null;
+export const isConnected = () =>
+  info.rpc !== null && info.rpc?.isConnected === true;
 
 export const backend = createBackend<
   {


### PR DESCRIPTION
Fixed the false "Connected" status in the `discord-rich-presence` plugin. 

The `isConnected()` function now includes an extra check to ensure the Discord RPC is actually connected, not just instantiated.
This makes the connection status properly reflect the RPC client's state. 

Fixes #2620.