### PR TITLE
fix: Set correct window class for X11 and Wayland

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "youtube-music",
+  "desktopName": "com.github.th_ch.youtube_music",
   "productName": "YouTube Music",
   "version": "3.6.2",
   "description": "YouTube Music Desktop App - including custom plugins",
@@ -71,6 +72,9 @@
     "linux": {
       "icon": "assets/generated/icons/png",
       "category": "AudioVideo",
+      "desktop": {
+        "StartupWMClass": "com.github.th_ch.youtube_music"
+      },
       "target": [
         {
           "target": "AppImage",

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,9 @@ if (config.get('options.disableHardwareAcceleration')) {
 }
 
 if (is.linux()) {
+  // Overrides WM_CLASS for X11 to correspond to icon filename
+  app.setName("com.github.th_ch.youtube_music");
+
   // Workaround for issue #2248
   if (
     process.env.XDG_SESSION_TYPE === 'wayland' ||


### PR DESCRIPTION
Attempt to fix all window class issues in X11 and Wayland:

- `desktopName` defines Wayland window class
- `StartupWMClass` in desktop file provides correct grouping and pinning
- `app.setName()` overrides `WM_CLASS` for X11

Closes #2687.