### PR TITLE
fix(synced-lyrics): Revert font-size behavior for non-fancy modes

### DIFF
--- a/src/plugins/synced-lyrics/renderer/renderer.tsx
+++ b/src/plugins/synced-lyrics/renderer/renderer.tsx
@@ -38,7 +38,10 @@ createEffect(() => {
       root.style.setProperty('--lyrics-active-offset', '0');
       break;
     case 'scale':
-      root.style.setProperty('--lyrics-font-size', '1.4rem');
+      root.style.setProperty(
+        '--lyrics-font-size',
+        'clamp(1.4rem, 1.1vmax, 3rem)',
+      );
       root.style.setProperty(
         '--lyrics-line-height',
         'var(--ytmusic-body-line-height)',
@@ -58,7 +61,10 @@ createEffect(() => {
       root.style.setProperty('--lyrics-active-offset', '0');
       break;
     case 'offset':
-      root.style.setProperty('--lyrics-font-size', '1.4rem');
+      root.style.setProperty(
+        '--lyrics-font-size',
+        'clamp(1.4rem, 1.1vmax, 3rem)',
+      );
       root.style.setProperty(
         '--lyrics-line-height',
         'var(--ytmusic-body-line-height)',
@@ -78,7 +84,10 @@ createEffect(() => {
       root.style.setProperty('--lyrics-active-offset', '5%');
       break;
     case 'focus':
-      root.style.setProperty('--lyrics-font-size', '1.4rem');
+      root.style.setProperty(
+        '--lyrics-font-size',
+        'clamp(1.4rem, 1.1vmax, 3rem)',
+      );
       root.style.setProperty(
         '--lyrics-line-height',
         'var(--ytmusic-body-line-height)',

--- a/src/plugins/synced-lyrics/style.css
+++ b/src/plugins/synced-lyrics/style.css
@@ -17,7 +17,7 @@
   /* Typography */
   --lyrics-font-family: Satoshi, Avenir, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell,
   Open Sans, Helvetica Neue, sans-serif;
-  --lyrics-font-size: 1.4rem;
+  --lyrics-font-size: clamp(1.4rem, 1.1vmax, 3rem);
   --lyrics-line-height: var(--ytmusic-body-line-height);
   --lyrics-width: 100%;
 


### PR DESCRIPTION
Fixes #2778 and reverts the font-size of lyrics for non-fancy modes to being scaled based on vmax again.