### PR TITLE
feat(api-server): add endpoint to get shuffle state

### DIFF
--- a/src/plugins/api-server/backend/routes/control.ts
+++ b/src/plugins/api-server/backend/routes/control.ts
@@ -173,7 +173,24 @@ const routes = {
       },
     },
   }),
-
+  getShuffleState: createRoute({
+    method: 'get',
+    path: `/api/${API_VERSION}/shuffle`,
+    summary: 'get shuffle state',
+    description: 'Get the current shuffle state',
+    responses: {
+      200: {
+        description: 'Success',
+        content: {
+          'application/json': {
+            schema: z.object({
+              state: z.boolean().nullable(),
+            }),
+          },
+        },
+      },
+    },
+  }),
   shuffle: createRoute({
     method: 'post',
     path: `/api/${API_VERSION}/shuffle`,
@@ -562,6 +579,25 @@ export const register = (
     ctx.status(204);
     return ctx.body(null);
   });
+
+  app.openapi(routes.getShuffleState, async (ctx) => {
+    const stateResponsePromise = new Promise<boolean>((resolve) => {
+      ipcMain.once(
+        'ytmd:get-shuffle-response',
+        (_, isShuffled: boolean | undefined) => {
+          return resolve(!!isShuffled);
+        },
+      );
+
+      controller.requestShuffleInformation();
+    });
+
+    const isShuffled = await stateResponsePromise;
+
+    ctx.status(200);
+    return ctx.json({ state: isShuffled });
+  });
+
   app.openapi(routes.shuffle, (ctx) => {
     controller.shuffle();
 

--- a/src/plugins/shortcuts/mpris-service.d.ts
+++ b/src/plugins/shortcuts/mpris-service.d.ts
@@ -86,7 +86,7 @@ declare module '@jellybrick/mpris-service' {
     supportedMimeTypes: string[];
     canQuit: boolean;
     canRaise: boolean;
-    canSetFullscreen?: boolean;
+    canUsePlayerControls?: boolean;
     desktopEntry?: string;
     hasTrackList: boolean;
 

--- a/src/providers/song-controls.ts
+++ b/src/providers/song-controls.ts
@@ -62,6 +62,9 @@ export default (win: BrowserWindow) => {
         win.webContents.send('ytmd:seek-by', seconds);
       }
     },
+    requestShuffleInformation: () => {
+      win.webContents.send('ytmd:get-shuffle');
+    },
     shuffle: () => win.webContents.send('ytmd:shuffle'),
     switchRepeat: (n: ArgsType<number> = 1) => {
       const repeat = parseNumberFromArgsType(n);

--- a/src/providers/song-info-front.ts
+++ b/src/providers/song-info-front.ts
@@ -87,6 +87,28 @@ export const setupVolumeChangedListener = singleton((api: YoutubePlayer) => {
   window.ipcRenderer.send('ytmd:volume-changed', api.getVolume());
 });
 
+export const setupShuffleChangedListener = singleton(() => {
+  const playerBar = document.querySelector('ytmusic-player-bar');
+
+  if (!playerBar) {
+    window.ipcRenderer.send('ytmd:shuffle-changed-supported', false);
+    return;
+  }
+
+  const observer = new MutationObserver(() => {
+    window.ipcRenderer.send(
+      'ytmd:shuffle-changed',
+      (playerBar?.attributes.getNamedItem('shuffle-on') ?? null) !== null,
+    );
+  });
+
+  observer.observe(playerBar, {
+    attributes: true,
+    childList: false,
+    subtree: false,
+  });
+});
+
 export const setupFullScreenChangedListener = singleton(() => {
   const playerBar = document.querySelector('ytmusic-player-bar');
 
@@ -137,6 +159,10 @@ export default (api: YoutubePlayer) => {
 
   window.ipcRenderer.on('ytmd:setup-volume-changed-listener', () => {
     setupVolumeChangedListener(api);
+  });
+
+  window.ipcRenderer.on('ytmd:setup-shuffle-changed-listener', () => {
+    setupShuffleChangedListener();
   });
 
   window.ipcRenderer.on('ytmd:setup-fullscreen-changed-listener', () => {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -80,6 +80,20 @@ async function onApiLoaded() {
       >('ytmusic-player-bar')
       ?.queue.shuffle();
   });
+
+  const isShuffled = () => {
+    const isShuffled =
+      document
+        .querySelector<HTMLElement>('ytmusic-player-bar')
+        ?.attributes.getNamedItem('shuffle-on') ?? null;
+
+    return isShuffled !== null;
+  };
+
+  window.ipcRenderer.on('ytmd:get-shuffle', () => {
+    window.ipcRenderer.send('ytmd:get-shuffle-response', isShuffled());
+  });
+
   window.ipcRenderer.on(
     'ytmd:update-like',
     (_, status: 'LIKE' | 'DISLIKE' = 'LIKE') => {


### PR DESCRIPTION
Added API endpoint: `/api/v1/shuffle` (GET)

`canSetFullscreen` has been renamed to `canUsePlayerControls` to be used by other player control states other than fullscreen. Can be reverted back if that's not the desired outcome.