### PR TITLE
feat(api-server): add `insertPosition` for `addSongToQueue`

### DIFF
--- a/src/plugins/api-server/backend/routes/control.ts
+++ b/src/plugins/api-server/backend/routes/control.ts
@@ -660,8 +660,8 @@ export const register = (
   app.openapi(routes.queueInfo, queueInfo);
 
   app.openapi(routes.addSongToQueue, (ctx) => {
-    const { videoId } = ctx.req.valid('json');
-    controller.addSongToQueue(videoId);
+    const { videoId, insertPosition } = ctx.req.valid('json');
+    controller.addSongToQueue(videoId, insertPosition);
 
     ctx.status(204);
     return ctx.body(null);

--- a/src/plugins/api-server/backend/scheme/queue.ts
+++ b/src/plugins/api-server/backend/scheme/queue.ts
@@ -6,6 +6,10 @@ export const QueueParamsSchema = z.object({
 
 export const AddSongToQueueSchema = z.object({
   videoId: z.string(),
+  insertPosition: z
+    .enum(['INSERT_AT_END', 'INSERT_AFTER_CURRENT_VIDEO'])
+    .optional()
+    .default('INSERT_AT_END'),
 });
 export const MoveSongInQueueSchema = z.object({
   toIndex: z.number(),

--- a/src/providers/song-controls.ts
+++ b/src/providers/song-controls.ts
@@ -97,11 +97,15 @@ export default (win: BrowserWindow) => {
       });
     },
     // Queue
-    addSongToQueue: (videoId: string) => {
+    addSongToQueue: (videoId: string, queueInsertPosition: string) => {
       const videoIdValue = parseStringFromArgsType(videoId);
       if (videoIdValue === null) return;
 
-      win.webContents.send('ytmd:add-to-queue', videoIdValue);
+      win.webContents.send(
+        'ytmd:add-to-queue',
+        videoIdValue,
+        queueInsertPosition,
+      );
     },
     moveSongInQueue: (
       fromIndex: ArgsType<number>,


### PR DESCRIPTION
Closes #2803, but hooking into POST `/api/v1/queue` instead of creating a new endpoint.

Request body:
```json
{
  "videoId": "...",
  "insertPosition": "INSERT_AFTER_CURRENT_VIDEO"
}
```

`insertPosition` can be omitted and will default to the original behavior (`INSERT_AT_END`).