### PR TITLE
feat(api-server): add endpoint to get volume state

### DIFF
--- a/src/plugins/api-server/backend/main.ts
+++ b/src/plugins/api-server/backend/main.ts
@@ -27,7 +27,7 @@ export const backend = createBackend<BackendType, APIServerConfig>({
     ctx.ipc.on('ytmd:player-api-loaded', () => {
       ctx.ipc.send('ytmd:setup-time-changed-listener');
       ctx.ipc.send('ytmd:setup-repeat-changed-listener');
-      ctx.ipc.send("ytmd:setup-volume-changed-listener")
+      ctx.ipc.send('ytmd:setup-volume-changed-listener');
     });
 
     ctx.ipc.on(

--- a/src/plugins/api-server/backend/main.ts
+++ b/src/plugins/api-server/backend/main.ts
@@ -27,11 +27,17 @@ export const backend = createBackend<BackendType, APIServerConfig>({
     ctx.ipc.on('ytmd:player-api-loaded', () => {
       ctx.ipc.send('ytmd:setup-time-changed-listener');
       ctx.ipc.send('ytmd:setup-repeat-changed-listener');
+      ctx.ipc.send("ytmd:setup-volume-changed-listener")
     });
 
     ctx.ipc.on(
       'ytmd:repeat-changed',
       (mode: RepeatMode) => (this.currentRepeatMode = mode),
+    );
+
+    ctx.ipc.on(
+      'ytmd:volume-changed',
+      (newVolume: number) => (this.volume = newVolume),
     );
 
     this.run(config.hostname, config.port);
@@ -95,6 +101,7 @@ export const backend = createBackend<BackendType, APIServerConfig>({
       ctx,
       () => this.songInfo,
       () => this.currentRepeatMode,
+      () => this.volume,
     );
     registerAuth(this.app, ctx);
 

--- a/src/plugins/api-server/backend/routes/control.ts
+++ b/src/plugins/api-server/backend/routes/control.ts
@@ -245,6 +245,24 @@ const routes = {
       },
     },
   }),
+  getVolumeState: createRoute({
+    method: 'get',
+    path: `/api/${API_VERSION}/volume`,
+    summary: 'get volume state',
+    description: 'Get the current volume state of the player',
+    responses: {
+      200: {
+        description: 'Success',
+        content: {
+          'application/json': {
+            schema: z.object({
+              state: z.number(),
+            }),
+          },
+        },
+      },
+    },
+  }),
   setFullscreen: createRoute({
     method: 'post',
     path: `/api/${API_VERSION}/fullscreen`,
@@ -496,6 +514,7 @@ export const register = (
   { window }: BackendContext<APIServerConfig>,
   songInfoGetter: () => SongInfo | undefined,
   repeatModeGetter: () => RepeatMode | undefined,
+  volumeGetter: () => number | undefined,
 ) => {
   const controller = getSongControls(window);
 
@@ -586,6 +605,10 @@ export const register = (
 
     ctx.status(204);
     return ctx.body(null);
+  });
+  app.openapi(routes.getVolumeState, (ctx) => {
+    ctx.status(200);
+    return ctx.json({ state: volumeGetter() ?? 0 });
   });
   app.openapi(routes.setFullscreen, (ctx) => {
     const { state } = ctx.req.valid('json');

--- a/src/plugins/api-server/backend/types.ts
+++ b/src/plugins/api-server/backend/types.ts
@@ -13,6 +13,7 @@ export type BackendType = {
   oldConfig?: APIServerConfig;
   songInfo?: SongInfo;
   currentRepeatMode?: RepeatMode;
+  volume?: number;
 
   init: (ctx: BackendContext<APIServerConfig>) => Promise<void>;
   run: (hostname: string, port: number) => void;


### PR DESCRIPTION
Added API endpoint: `/api/v1/volume` (GET)

This returns the current volume of the player.
