### PR TITLE
fix: fix build.linux.desktop.entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,9 @@
       "icon": "assets/generated/icons/png",
       "category": "AudioVideo",
       "desktop": {
-        "entry": "com.github.th_ch.youtube_music"
+        "entry": {
+          "StartupWMClass": "com.github.th_ch.youtube_music"
+        }
       },
       "target": [
         {


### PR DESCRIPTION
This fixes the `build.linux.desktop.entry` in the package.json

According to electron-builder's documentation, the `entry` should be an **object** describing the desktop entry
https://www.electron.build/app-builder-lib.interface.linuxdesktopfile#entry

Since commit 8de27358d38dba75c4c3e44111ca5a2ef9f75ea5, the `entry` is being set to a **string**, so the .desktop file generated has bogus key-values.
 
<details>
  <summary>before this PR</summary>

```
[Desktop Entry]
0=c
1=o
2=m
3=.
4=g
5=i
6=t
7=h
8=u
9=b
10=.
11=t
12=h
13=_
14=c
15=h
16=.
17=y
18=o
19=u
20=t
21=u
22=b
23=e
24=_
25=m
26=u
27=s
28=i
29=c
Name=YouTube Music
Exec=AppRun --no-sandbox %U
Terminal=false
Type=Application
Icon=youtube-music
StartupWMClass=YouTube Music
X-AppImage-Version=3.7.1
Comment=YouTube Music Desktop App bundled with custom plugins (and built-in ad blocker / downloader)
Categories=AudioVideo;
```

</details>

<details>
  <summary>after this PR</summary>
  
```
[Desktop Entry]
Name=YouTube Music
Exec=AppRun --no-sandbox %U
Terminal=false
Type=Application
Icon=youtube-music
StartupWMClass=com.github.th_ch.youtube_music
X-AppImage-Version=3.7.1
Comment=YouTube Music Desktop App bundled with custom plugins (and built-in ad blocker / downloader)
Categories=AudioVideo;
```

</details>

(.desktop files above were extracted from the AppImages generated)