### PR TITLE
Fix reverse direction of synced lyrics for persian or other rtl languages

### DIFF
--- a/src/plugins/synced-lyrics/renderer/components/SyncedLine.tsx
+++ b/src/plugins/synced-lyrics/renderer/components/SyncedLine.tsx
@@ -50,7 +50,7 @@ export const SyncedLine = ({ line }: SyncedLineProps) => {
         _ytAPI?.seekTo(line.timeInMs / 1000);
       }}
     >
-      <div class="text-lyrics description ytmusic-description-shelf-renderer">
+      <div dir="auto" class="text-lyrics description ytmusic-description-shelf-renderer">
         <yt-formatted-string
           text={{
             runs: [{ text: config()?.showTimeCodes ? `[${line.time}] ` : '' }],


### PR DESCRIPTION
Add direction auto to synced lyrics to fix reverse direction in rtl languages