### PR TITLE
fix: remove disable-gpu-memory-buffer-video-frames flag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -134,14 +134,6 @@ if (is.linux()) {
   // Overrides WM_CLASS for X11 to correspond to icon filename
   app.setName('com.github.th_ch.youtube_music');
 
-  // Workaround for issue #2248
-  if (
-    process.env.XDG_SESSION_TYPE === 'wayland' ||
-    process.env.WAYLAND_DISPLAY
-  ) {
-    app.commandLine.appendSwitch('disable-gpu-memory-buffer-video-frames');
-  }
-
   // Stops chromium from launching its own MPRIS service
   if (config.plugins.isEnabled('shortcuts')) {
     app.commandLine.appendSwitch('disable-features', 'MediaSessionService');


### PR DESCRIPTION
As I mentioned in my previous PR #2519 , the original issue #2248 was fixed in chromium >=131 (electron >=34)

Since the project now uses electron `34.0.2`, I tested it again and the workaround is **not** needed anymore.