### PR TITLE
fix(vite): set server.cors.origin

### DIFF
--- a/electron.vite.config.mts
+++ b/electron.vite.config.mts
@@ -147,6 +147,11 @@ export default defineConfig({
       resolve: {
         alias: resolveAlias,
       },
+      server: {
+        cors: {
+          origin: 'https://music.youtube.com',
+        },
+      },
     };
 
     if (mode === 'development') {


### PR DESCRIPTION
Fixes #2979

<hr>

Vite `v6.0.9` changed the default value of `server.cors` from `true` to `false` (security advisory: https://github.com/vitejs/vite/security/advisories/GHSA-vg6x-rcgg-rjx6 )

As a consequence, we get some CORS erros and the plugins are not applied to the page
```
Access to script at 'http://localhost:5173/@vite/client' from origin 'https://music.youtube.com'
has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the
requested resource.

Access to script at 'http://localhost:5173/renderer.ts' from origin 'https://music.youtube.com'
has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the
requested resource.
```
<hr>

To fix that, this PR sets `server.cors.origin` to `https://music.youtube.com`