### PR TITLE
fix(downloader): correct logic for YouTube Premium detection

### DIFF
--- a/src/plugins/downloader/main/index.ts
+++ b/src/plugins/downloader/main/index.ts
@@ -57,7 +57,7 @@ let playingUrl: string;
 
 const isYouTubePremium = () =>
   win.webContents.executeJavaScript(
-    '!document.querySelector(\'#endpoint[href="/music_premium"]\')',
+    '!!document.querySelector(\'#endpoint[href="/music_premium"]\')',
   ) as Promise<boolean>;
 
 const sendError = (error: Error, source?: string) => {


### PR DESCRIPTION
Another fix to address 304 errors when downloading (#2888).