### PR TITLE
fix(plugin-loader): update context filtering logic for backend mode

### DIFF
--- a/vite-plugins/plugin-loader.mts
+++ b/vite-plugins/plugin-loader.mts
@@ -130,7 +130,7 @@ export default function (
 
       const stubContexts =
         mode === 'backend'
-          ? contexts.filter((ctx) => ctx !== 'backend')
+          ? contexts.filter((ctx) => ctx !== 'menu')
           : contexts;
       for (const ctx of stubContexts) {
         if (stubMap.has(ctx)) {


### PR DESCRIPTION
Fixes #2988

This filters out the `menu` context (instead of `backend`) if mode is `backend`.
 
For reference, the previous version of `plugin-loader` pops out the `menu` [context](https://github.com/th-ch/youtube-music/blob/v3.7.2/vite-plugins/plugin-loader.mts#L91) if the [mode](https://github.com/th-ch/youtube-music/blob/v3.7.2/vite-plugins/plugin-loader.mts#L144) is `backend`