### PR TITLE
fix: Match engines.pnpm with the pnpm version used to create the lock files

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
   },
   "engines": {
     "node": ">=18",
-    "pnpm": ">=8"
+    "pnpm": ">=10"
   },
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
pnpm uses base64 encoded hashes for some things including the patches which broke when I updated the package for NixOS.