### PR TITLE
fix(no-google-login): Remove Library icon removal code

### DIFF
--- a/src/plugins/no-google-login/index.ts
+++ b/src/plugins/no-google-login/index.ts
@@ -22,27 +22,5 @@ export default createPlugin({
         node.remove();
       }
     }
-
-    // Remove the library button
-    const libraryIconPath =
-      'M16,6v2h-2v5c0,1.1-0.9,2-2,2s-2-0.9-2-2s0.9-2,2-2c0.37,0,0.7,0.11,1,0.28V6H16z M18,20H4V6H3v15h15V20z M21,3H6v15h15V3z M7,4h13v13H7V4z';
-    const observer = new MutationObserver(() => {
-      const menuEntries = document.querySelectorAll(
-        '#items ytmusic-guide-entry-renderer',
-      );
-      menuEntries.forEach((item) => {
-        const icon = item.querySelector('path');
-        if (icon) {
-          observer.disconnect();
-          if (icon.getAttribute('d') === libraryIconPath) {
-            item.remove();
-          }
-        }
-      });
-    });
-    observer.observe(document.documentElement, {
-      childList: true,
-      subtree: true,
-    });
   },
 });


### PR DESCRIPTION
This PR removes the code responsible for detecting and removing the library icon in the sidebar. The MutationObserver logic and associated libraryIconPath check have been deleted, ensuring the library button remains unaffected.

- Not sure why this got looped in with the no-google-login plugin. I'm not sure how remove the Library icon is aligned with the goal of "Remove Google login buttons and links from the interface". The library is not a Google Account link. It's a link specifically to a core feature of the app and any music streaming platform. 




#784

