### PR TITLE
fix: Filter for only `MusicResponsiveListItem` in playlist items

### DIFF
--- a/src/plugins/downloader/main/index.ts
+++ b/src/plugins/downloader/main/index.ts
@@ -639,7 +639,12 @@ export async function downloadPlaylist(givenUrl?: string | URL) {
   try {
     playlist = await yt.music.getPlaylist(playlistId);
     if (playlist?.items) {
-      items.push(...playlist.items.as(YTNodes.MusicResponsiveListItem));
+      const filteredItems = playlist.items.filter(
+        (item): item is YTNodes.MusicResponsiveListItem =>
+          item instanceof YTNodes.MusicResponsiveListItem,
+      );
+
+      items.push(...filteredItems);
     }
   } catch (error: unknown) {
     sendError(
@@ -674,9 +679,13 @@ export async function downloadPlaylist(givenUrl?: string | URL) {
 
   while (playlist.has_continuation) {
     playlist = await playlist.getContinuation();
-    if (playlist?.items) {
-      items.push(...playlist.items.as(YTNodes.MusicResponsiveListItem));
-    }
+
+    const filteredItems = playlist.items.filter(
+      (item): item is YTNodes.MusicResponsiveListItem =>
+        item instanceof YTNodes.MusicResponsiveListItem,
+    );
+
+    items.push(...filteredItems);
   }
 
   if (items.length === 1) {


### PR DESCRIPTION
This is to filter out the `ContinuationItem` that YouTube.js now has in the items in a playlist that cause an error.

Fixes https://github.com/th-ch/youtube-music/issues/3007
Also fixes https://github.com/th-ch/youtube-music/issues/2978

This needs to be applied with [PR #3105](https://github.com/th-ch/youtube-music/pull/3015)