### PR TITLE
Synced Lyrics: Also search for lyrics with the original title language

### DIFF
--- a/src/plugins/synced-lyrics/providers/LRCLib.ts
+++ b/src/plugins/synced-lyrics/providers/LRCLib.ts
@@ -11,10 +11,17 @@ export class LRCLib implements LyricProvider {
 
   async search({
     title,
+    alternativeTitle,
     artist,
     album,
     songDuration,
+    tags,
   }: SearchSongInfo): Promise<LyricResult | null> {
+    // I won't enable this as the default since I'm not sure if the "alternative title"
+    // is always the original language. And anyway the artist name is usually in English.
+    // Not in the original, and that is a little bit harder to extract.
+    // const trackName = alternativeTitle || title;
+    
     let query = new URLSearchParams({
       artist_name: artist,
       track_name: title,
@@ -42,7 +49,9 @@ export class LRCLib implements LyricProvider {
         return null;
       }
 
-      query = new URLSearchParams({ q: title });
+      // Try to search with the alternative title
+      const trackName = alternativeTitle || title;
+      query = new URLSearchParams({ q: `${trackName}` });
       url = `${this.baseUrl}/api/search?${query.toString()}`;
 
       response = await fetch(url);
@@ -54,6 +63,22 @@ export class LRCLib implements LyricProvider {
       if (!Array.isArray(data)) {
         throw new Error(`Expected an array, instead got ${typeof data}`);
       }
+      
+      // If still no results, try with the original title as fallback
+      if (data.length === 0 && alternativeTitle) {
+        query = new URLSearchParams({ q: title });
+        url = `${this.baseUrl}/api/search?${query.toString()}`;
+
+        response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(`bad HTTPStatus(${response.statusText})`);
+        }
+
+        data = (await response.json()) as LRCLIBSearchResponse;
+        if (!Array.isArray(data)) {
+          throw new Error(`Expected an array, instead got ${typeof data}`);
+        }
+      }
     }
 
     const filteredResults = [];
@@ -63,6 +88,7 @@ export class LRCLib implements LyricProvider {
       const artists = artist.split(/[&,]/g).map((i) => i.trim());
       const itemArtists = artistName.split(/[&,]/g).map((i) => i.trim());
 
+      // Try to match using artist name first
       const permutations = [];
       for (const artistA of artists) {
         for (const artistB of itemArtists) {
@@ -76,9 +102,39 @@ export class LRCLib implements LyricProvider {
         }
       }
 
-      const ratio = Math.max(
+      let ratio = Math.max(
         ...permutations.map(([x, y]) => jaroWinkler(x, y)),
       );
+
+      // If direct artist match is below threshold and we have tags, try matching with tags
+      if (ratio <= 0.9 && tags && tags.length > 0) {
+        // Filter out the artist from tags to avoid duplicate comparisons
+        const filteredTags = tags.filter(tag => tag.toLowerCase() !== artist.toLowerCase());
+        
+        const tagPermutations = [];
+        // Compare each tag with each item artist
+        for (const tag of filteredTags) {
+          for (const itemArtist of itemArtists) {
+            tagPermutations.push([tag.toLowerCase(), itemArtist.toLowerCase()]);
+          }
+        }
+        
+        // Compare each item artist with each tag
+        for (const itemArtist of itemArtists) {
+          for (const tag of filteredTags) {
+            tagPermutations.push([itemArtist.toLowerCase(), tag.toLowerCase()]);
+          }
+        }
+        
+        if (tagPermutations.length > 0) {
+          const tagRatio = Math.max(
+            ...tagPermutations.map(([x, y]) => jaroWinkler(x, y)),
+          );
+          
+          // Use the best match ratio between direct artist match and tag match
+          ratio = Math.max(ratio, tagRatio);
+        }
+      }
 
       if (ratio <= 0.9) continue;
       filteredResults.push(item);

--- a/src/plugins/synced-lyrics/providers/LRCLib.ts
+++ b/src/plugins/synced-lyrics/providers/LRCLib.ts
@@ -17,10 +17,6 @@ export class LRCLib implements LyricProvider {
     songDuration,
     tags,
   }: SearchSongInfo): Promise<LyricResult | null> {
-    // I won't enable this as the default since I'm not sure if the "alternative title"
-    // is always the original language. And anyway the artist name is usually in English.
-    // Not in the original, and that is a little bit harder to extract.
-    // const trackName = alternativeTitle || title;
     
     let query = new URLSearchParams({
       artist_name: artist,
@@ -49,7 +45,7 @@ export class LRCLib implements LyricProvider {
         return null;
       }
 
-      // Try to search with the alternative title
+      // Try to search with the alternative title (original language)
       const trackName = alternativeTitle || title;
       query = new URLSearchParams({ q: `${trackName}` });
       url = `${this.baseUrl}/api/search?${query.toString()}`;

--- a/src/plugins/synced-lyrics/types.ts
+++ b/src/plugins/synced-lyrics/types.ts
@@ -32,7 +32,7 @@ export interface LyricResult {
 }
 
 // prettier-ignore
-export type SearchSongInfo = Pick<SongInfo, 'title' | 'artist' | 'album' | 'songDuration' | 'videoId'>;
+export type SearchSongInfo = Pick<SongInfo, 'title' | 'alternativeTitle' | 'artist' | 'album' | 'songDuration' | 'videoId' | 'tags'>;
 
 export interface LyricProvider {
   name: string;

--- a/src/providers/song-info.ts
+++ b/src/providers/song-info.ts
@@ -42,6 +42,7 @@ export interface SongInfo {
   videoId: string;
   playlistId?: string;
   mediaType: MediaType;
+  tags?: string[];
 }
 
 // Grab the native image using the src
@@ -83,6 +84,7 @@ const handleData = async (
     videoId: '',
     playlistId: '',
     mediaType: MediaType.Audio,
+    tags: [],
   } satisfies SongInfo;
 
   const microformat = data.microformat?.microformatDataRenderer;
@@ -96,6 +98,7 @@ const handleData = async (
     songInfo.alternativeTitle = microformat.linkAlternates.find(
       (link) => link.title,
     )?.title;
+    songInfo.tags = microformat.tags;
   }
 
   const { videoDetails } = data;

--- a/src/providers/song-info.ts
+++ b/src/providers/song-info.ts
@@ -98,7 +98,7 @@ const handleData = async (
     songInfo.alternativeTitle = microformat.linkAlternates.find(
       (link) => link.title,
     )?.title;
-    songInfo.tags = microformat.tags;
+    songInfo.tags = Array.isArray(microformat.tags) ? microformat.tags : [];
   }
 
   const { videoDetails } = data;


### PR DESCRIPTION
I need to test this a bit more, since I have only tested with Japanese songs (Interface in English (US)), I'm not sure if maybe we should keep the original matching as a toggle in the menu.

Added a new array to the song-info type which gets the tags array from microformat.

From what I've seen this array sometimes contains the english artist name, the original artist name, the album name, the album or song producer/composer in both languages, the album name, the song name, etc.

Then we pass alternativeTitle and tags to LRCLib search, here it first tries to the exact match, then searches by the alternative title first, if not found it will fallback to searching the title only again.

On filtering, if the localized artist match is below the threshold, it will compare each tag with each artist from the response.

The songs I've tested are 
Oracle - Amane Kanata.
Chandelier - Murasaki Shion

Both weren't working before and are now.