### PR TITLE
fix(mpris): keep MPRIS volume in sync with the actual volume

### DIFF
--- a/src/plugins/shortcuts/mpris.ts
+++ b/src/plugins/shortcuts/mpris.ts
@@ -305,31 +305,14 @@ function registerMPRIS(win: BrowserWindow) {
       console.trace(error);
     });
 
-    let mprisVolNewer = false;
-    let autoUpdate = false;
     ipcMain.on('ytmd:volume-changed', (_, newVol) => {
-      if (~~(player.volume * 100) !== newVol) {
-        if (mprisVolNewer) {
-          mprisVolNewer = false;
-          autoUpdate = false;
-        } else {
-          autoUpdate = true;
-          player.volume = Number.parseFloat((newVol / 100).toFixed(2));
-          mprisVolNewer = false;
-          autoUpdate = false;
-        }
-      }
+      player.volume = Number.parseFloat((newVol / 100).toFixed(2));
     });
 
     player.on('volume', (newVolume: number) => {
       if (config.plugins.isEnabled('precise-volume')) {
         // With precise volume we can set the volume to the exact value.
-        const newVol = ~~(newVolume * 100);
-        if (~~(player.volume * 100) !== newVol && !autoUpdate) {
-          mprisVolNewer = true;
-          autoUpdate = false;
-          win.webContents.send('setVolume', newVol);
-        }
+        win.webContents.send('setVolume', ~~(newVolume * 100));
       } else {
         setVolume(newVolume * 100);
       }


### PR DESCRIPTION
Fixes #3225 by reverting some of the modifications from 9da0e43

The code introduced in that commit was meant to prevent a supposed recursion described in https://github.com/th-ch/youtube-music/pull/1005#issuecomment-1415717977, but I don't think it happens anymore (at least not in the current codebase, maybe it did in the past)

<hr>

Now we can call this multiple times and it'll increment the volume properly (+10% volume per call)
`playerctl --player=YoutubeMusic volume 0.1+`

Before, it would always get the same frozen volume and add 0.1 to it, so it would stop incrementing after the first call.