### PR TITLE
feat(content-warning-skipper): Implement Content Warning Skipper

### DIFF
--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -844,6 +844,10 @@
         "visualizer-type": "Visualizer Type"
       },
       "name": "Visualizer"
+    },
+    "content-warning-skipper": {
+        "description": "Skips content warnings",
+        "name": "Content Warning Skipper"
     }
   }
 }

--- a/src/i18n/resources/fr.json
+++ b/src/i18n/resources/fr.json
@@ -840,6 +840,10 @@
         "visualizer-type": "Type de visualiseur"
       },
       "name": "Visualiseur"
+    },
+    "content-warning-skipper": {
+        "description": "Saute les avertissements de contenu",
+        "name": "Sauteur d'avertissement de contenu"
     }
   }
 }

--- a/src/i18n/resources/fr.json
+++ b/src/i18n/resources/fr.json
@@ -842,8 +842,8 @@
       "name": "Visualiseur"
     },
     "content-warning-skipper": {
-        "description": "Saute les avertissements de contenu",
-        "name": "Sauteur d'avertissement de contenu"
+        "description": "Ignore automatiquement les avertissements de contenu",
+        "name": "Suppresseur d'avertissement de contenu"
     }
   }
 }

--- a/src/plugins/content-warning-skipper/index.ts
+++ b/src/plugins/content-warning-skipper/index.ts
@@ -1,0 +1,24 @@
+import { createPlugin } from '@/utils';
+import { t } from '@/i18n';
+
+import { waitForElement } from '@/utils/wait-for-element';
+
+export default createPlugin({
+  name: () => t('plugins.content-warning-skipper.name'),
+  description: () => t('plugins.content-warning-skipper.description'),
+  restartNeeded: false,
+  renderer: () => {
+    waitForElement<HTMLElement>('#button yt-button-renderer button').then(
+      (button) => {
+        if (!button) return;
+
+        const isVisible = button.offsetParent !== null;
+        const isEnabled = button.getAttribute('aria-disabled') === 'false';
+
+        if (isVisible && isEnabled) {
+          button.click();
+        }
+      },
+    );
+  },
+});

--- a/src/plugins/content-warning-skipper/index.ts
+++ b/src/plugins/content-warning-skipper/index.ts
@@ -1,24 +1,26 @@
 import { createPlugin } from '@/utils';
 import { t } from '@/i18n';
 
-import { waitForElement } from '@/utils/wait-for-element';
-
 export default createPlugin({
   name: () => t('plugins.content-warning-skipper.name'),
   description: () => t('plugins.content-warning-skipper.description'),
   restartNeeded: false,
   renderer: () => {
-    waitForElement<HTMLElement>('#button yt-button-renderer button').then(
-      (button) => {
-        if (!button) return;
+    const observer = new MutationObserver(() => {
+      const button = document.querySelector<HTMLElement>(
+        '#button yt-button-renderer button',
+      );
+      if (!button) return;
 
-        const isVisible = button.offsetParent !== null;
-        const isEnabled = button.getAttribute('aria-disabled') === 'false';
+      const isVisible = button.offsetParent !== null;
+      const isEnabled = button.getAttribute('aria-disabled') === 'false';
 
-        if (isVisible && isEnabled) {
-          button.click();
-        }
-      },
-    );
+      if (isVisible && isEnabled) {
+        button.click();
+        console.log('Content warning button triggered');
+      }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
   },
 });


### PR DESCRIPTION
This plugin automatically handles content warnings on YouTube by detecting and clicking the "I understand and want to proceed" button when it appears. The button is automatically clicked only if it's visible and enabled, ensuring that users are not interrupted by content warnings. This plugin improves the user experience by bypassing content warnings seamlessly.