### PR TITLE
feat(scrobblers): Only broadcast the main artist to Last.fm

### DIFF
--- a/src/plugins/scrobbler/services/lastfm.ts
+++ b/src/plugins/scrobbler/services/lastfm.ts
@@ -135,7 +135,7 @@ export class LastFmScrobbler extends ScrobblerBase {
     const postData: LastFmSongData = {
       track: title,
       duration: songInfo.songDuration,
-      artist: songInfo.artist,
+      artist: songInfo.artist.replace(/(.*?)(?:&|,|featuring).*$/, "$1"),
       ...(songInfo.album ? { album: songInfo.album } : undefined), // Will be undefined if current song is a video
       api_key: config.scrobblers.lastfm.apiKey,
       sk: config.scrobblers.lastfm.sessionKey,


### PR DESCRIPTION
Songs on Last.fm only have the main artist set, and including any featured artists hinders Last.fm's song detection

![image](https://github.com/user-attachments/assets/04d3bf2f-d87a-481e-a9cc-64d31fb7c18a)
![image](https://github.com/user-attachments/assets/78fdd071-20cc-4b68-b6e4-0a40c225ee8d)

Despite a song having multiple artists, Last.fm only considers the main artist as the "Artist" of the song.