### PR TITLE
fix(precise-volume): replace constructor check for volume slider

### DIFF
--- a/src/plugins/precise-volume/renderer.ts
+++ b/src/plugins/precise-volume/renderer.ts
@@ -155,9 +155,9 @@ export const onPlayerApiReady = async (
   function setupSliderObserver() {
     const sliderObserver = new MutationObserver((mutations) => {
       for (const mutation of mutations) {
-        if (mutation.target instanceof HTMLInputElement) {
+        if (mutation.target.nodeName === 'TP-YT-PAPER-SLIDER') {
           // This checks that volume-slider was manually set
-          const target = mutation.target;
+          const target = mutation.target as HTMLInputElement;
           const targetValueNumeric = Number(target.value);
           if (
             mutation.oldValue !== target.value &&


### PR DESCRIPTION
Fixes #3351

`#volume-slider` is not a native input element (anymore?). This now checks if it is `tp-yt-paper-slider`, which also acts like an input element.