### PR TITLE
fix: use gtk 3 switch as workaround

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,9 @@ protocol.registerSchemesAsPrivileged([
   { scheme: 'mailto', privileges: { standard: true } },
 ]);
 
+// https://github.com/electron/electron/issues/46538#issuecomment-2808806722
+app.commandLine.appendSwitch('gtk-version', '3');
+
 // Ozone platform hint: Required for Wayland support
 app.commandLine.appendSwitch('ozone-platform-hint', 'auto');
 // SharedArrayBuffer: Required for downloader (@ffmpeg/core-mt)

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,9 @@ protocol.registerSchemesAsPrivileged([
 ]);
 
 // https://github.com/electron/electron/issues/46538#issuecomment-2808806722
-app.commandLine.appendSwitch('gtk-version', '3');
+if (process.platform === 'linux') {
+  app.commandLine.appendSwitch('gtk-version', '3');
+}
 
 // Ozone platform hint: Required for Wayland support
 app.commandLine.appendSwitch('ozone-platform-hint', 'auto');

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,7 @@ protocol.registerSchemesAsPrivileged([
 ]);
 
 // https://github.com/electron/electron/issues/46538#issuecomment-2808806722
-if (process.platform === 'linux') {
+if (is.linux()) {
   app.commandLine.appendSwitch('gtk-version', '3');
 }
 


### PR DESCRIPTION
The latest version of Electron will throw out an error with GNOME:

```bash
Running (process:10985): Gtk-ERROR **: 16:23:58.349: GTK 2/3 symbols detected. Using GTK 2/3 and GTK 4 in the same process is not supported
```

This commit applies the workaround mentioned [here](https://github.com/electron/electron/issues/46538#issuecomment-2808806722) and [here](https://github.com/electron/electron/blob/main/docs/breaking-changes.md#changed-gtk-4-is-default-when-running-gnome).