### PR TITLE
feat(api-server): add optional params for search

### DIFF
--- a/src/plugins/api-server/backend/routes/control.ts
+++ b/src/plugins/api-server/backend/routes/control.ts
@@ -754,8 +754,8 @@ export const register = (
     return ctx.body(null);
   });
   app.openapi(routes.search, async (ctx) => {
-    const body = ctx.req.valid('json');
-    const response = await controller.search(body);
+    const { query, params, continuation } = ctx.req.valid('json');
+    const response = await controller.search(query, params, continuation);
 
     ctx.status(200);
     return ctx.json(response as object);

--- a/src/plugins/api-server/backend/routes/control.ts
+++ b/src/plugins/api-server/backend/routes/control.ts
@@ -754,8 +754,8 @@ export const register = (
     return ctx.body(null);
   });
   app.openapi(routes.search, async (ctx) => {
-    const { query } = ctx.req.valid('json');
-    const response = await controller.search(query);
+    const body = ctx.req.valid('json');
+    const response = await controller.search(body);
 
     ctx.status(200);
     return ctx.json(response as object);

--- a/src/plugins/api-server/backend/scheme/search.ts
+++ b/src/plugins/api-server/backend/scheme/search.ts
@@ -2,4 +2,6 @@ import { z } from '@hono/zod-openapi';
 
 export const SearchSchema = z.object({
   query: z.string(),
+  params: z.string().optional(),
+  continuation: z.string().optional(),
 });

--- a/src/providers/song-controls.ts
+++ b/src/providers/song-controls.ts
@@ -134,16 +134,12 @@ export default (win: BrowserWindow) => {
     },
     clearQueue: () => win.webContents.send('ytmd:clear-queue'),
 
-    search: (params: {
-      query: string;
-      params?: string;
-      continuation?: string;
-    }) =>
+    search: (query: string, params?: string, continuation?: string) =>
       new Promise((resolve) => {
         ipcMain.once('ytmd:search-results', (_, result) => {
           resolve(result as string);
         });
-        win.webContents.send('ytmd:search', params);
+        win.webContents.send('ytmd:search', query, params, continuation);
       }),
   };
 };

--- a/src/providers/song-controls.ts
+++ b/src/providers/song-controls.ts
@@ -134,12 +134,16 @@ export default (win: BrowserWindow) => {
     },
     clearQueue: () => win.webContents.send('ytmd:clear-queue'),
 
-    search: (query: string) =>
+    search: (params: {
+      query: string;
+      params?: string;
+      continuation?: string;
+    }) =>
       new Promise((resolve) => {
         ipcMain.once('ytmd:search-results', (_, result) => {
           resolve(result as string);
         });
-        win.webContents.send('ytmd:search', query);
+        win.webContents.send('ytmd:search', params);
       }),
   };
 };

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -277,20 +277,30 @@ async function onApiLoaded() {
     });
   });
 
-  window.ipcRenderer.on('ytmd:search', async (_, query: string) => {
-    const app = document.querySelector<YouTubeMusicAppElement>('ytmusic-app');
-    const searchBox =
-      document.querySelector<SearchBoxElement>('ytmusic-search-box');
+  window.ipcRenderer.on(
+    'ytmd:search',
+    async (
+      _,
+      params: {
+        query: string;
+        params?: string;
+        continuation?: string;
+      },
+    ) => {
+      const app = document.querySelector<YouTubeMusicAppElement>('ytmusic-app');
+      const searchBox =
+        document.querySelector<SearchBoxElement>('ytmusic-search-box');
 
-    if (!app || !searchBox) return;
+      if (!app || !searchBox) return;
 
-    const result = await app.networkManager.fetch('/search', {
-      query,
-      suggestStats: searchBox.getSearchboxStats(),
-    });
+      const result = await app.networkManager.fetch('/search', {
+        ...params,
+        suggestStats: searchBox.getSearchboxStats(),
+      });
 
-    window.ipcRenderer.send('ytmd:search-results', result);
-  });
+      window.ipcRenderer.send('ytmd:search-results', result);
+    },
+  );
 
   const video = document.querySelector('video')!;
   const audioContext = new AudioContext();

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -286,12 +286,6 @@ async function onApiLoaded() {
 
       if (!app || !searchBox) return;
 
-      console.log({
-        query,
-        params,
-        continuation,
-      });
-
       const result = await app.networkManager.fetch('/search', {
         query,
         params,

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -279,22 +279,23 @@ async function onApiLoaded() {
 
   window.ipcRenderer.on(
     'ytmd:search',
-    async (
-      _,
-      params: {
-        query: string;
-        params?: string;
-        continuation?: string;
-      },
-    ) => {
+    async (_, query: string, params?: string, continuation?: string) => {
       const app = document.querySelector<YouTubeMusicAppElement>('ytmusic-app');
       const searchBox =
         document.querySelector<SearchBoxElement>('ytmusic-search-box');
 
       if (!app || !searchBox) return;
 
+      console.log({
+        query,
+        params,
+        continuation,
+      });
+
       const result = await app.networkManager.fetch('/search', {
-        ...params,
+        query,
+        params,
+        continuation,
         suggestStats: searchBox.getSearchboxStats(),
       });
 


### PR DESCRIPTION
This PR adds optional params to the `/search` API.
- `params`: More results from each category (songs, videos, artists, etc.)
- `continuation`: Continuation of each category (lazy loading)