### PR TITLE
fix(style): fix duplicated scrollbar

### DIFF
--- a/src/youtube-music.css
+++ b/src/youtube-music.css
@@ -96,3 +96,8 @@ tp-yt-iron-dropdown,
 tp-yt-paper-dialog {
   app-region: no-drag;
 }
+
+/* Fix duplicated scrollbar */
+body {
+  overflow: hidden !important;
+}


### PR DESCRIPTION
Closes #3039

This PR just hides the body's overflow (catch-all solution to never show the double scrollbars)

|before|after|
|-|-|
|![ytm-before](https://github.com/user-attachments/assets/b7ca4fea-2875-4fee-996e-5301c0ba5f83)|![ytm-after](https://github.com/user-attachments/assets/9258e1a5-a62d-4d95-9ff5-1d7939e93375)|

<hr>

The bug only seems to happen when:
-  **in-app menu** is enabled
- "notification-action" popup is triggered (`save to playlist`, `add to liked songs`, etc)

I think it has something to do with the top margin added by the **in-app menu**
(plus the 1px added by the notification container)

<hr>

Alternative solution. This targets the notification container specifically.

```css
ytmusic-notification-action-renderer {
  position: fixed;
  z-index: 103; /* magic number from `tp-yt-paper-toast`, but anything >4 is fine */
  /* z-index is needed because otherwise it gets hidden under the left drawer menu */
}
```

Or even

```css
ytmusic-notification-action-renderer {
  position: absolute;
}
yt-notification-action-renderer {
  width: 0 !important; /* the width is set to 1px, and it somehow causes vertical scroll to appear */
  /* height is also set to 1px, but just the width is enough */
}
```

<hr>

> [!NOTE] 
> Interestingly, the double scrollbars don't go away when you close the notification popup... 
> 
> Youtube just creates a node for each notification in the DOM tree, then hides it with css and never removes it.
>
> It's a bit concerning in terms of memory, but that's a separate issue lol.