### PR TITLE
 fix(discord): Presence reacts to pause/play

### DIFF
--- a/src/plugins/discord/discord-service.ts
+++ b/src/plugins/discord/discord-service.ts
@@ -275,7 +275,6 @@ export class DiscordService {
     }
 
     // Cache the latest song info
-    this.lastSongInfo = songInfo;
     this.timerManager.clear(TimerKey.ClearActivity);
 
     if (!this.rpc || !this.ready) {
@@ -292,7 +291,10 @@ export class DiscordService {
       !songChanged &&
       isSeek(this.lastSongInfo?.elapsedSeconds ?? 0, elapsedSeconds);
 
-    if (songChanged || pauseChanged || seeked) {
+    if (
+      (songChanged || pauseChanged || seeked) &&
+      this.lastSongInfo !== undefined
+    ) {
       this.timerManager.clear(TimerKey.UpdateTimeout);
 
       const activityInfo = this.buildActivityInfo(songInfo, this.config);
@@ -318,7 +320,6 @@ export class DiscordService {
           console.error(LoggerPrefix, 'Failed to set throttled activity:', err),
         );
 
-      this.lastSongInfo.elapsedSeconds = elapsedSeconds;
       this.lastProgressUpdate = now;
       this.setActivityTimeout();
     } else {
@@ -348,6 +349,7 @@ export class DiscordService {
         remainingThrottle,
       );
     }
+    this.lastSongInfo = { ...songInfo };
   }
 
   /**


### PR DESCRIPTION
Previously, last song info was always set to current song so it failed to respond to changes in pause. This fixes that bug.