### PR TITLE
feat(api-server): Improved api-server volume and like/dislike state

### DIFF
--- a/src/plugins/api-server/backend/types.ts
+++ b/src/plugins/api-server/backend/types.ts
@@ -3,7 +3,7 @@ import { serve } from '@hono/node-server';
 
 import type { BackendContext } from '@/types/contexts';
 import type { SongInfo } from '@/providers/song-info';
-import type { RepeatMode } from '@/types/datahost-get-state';
+import type { LikeType, RepeatMode, VolumeState } from '@/types/datahost-get-state';
 import type { APIServerConfig } from '../config';
 
 export type HonoApp = Hono;
@@ -13,7 +13,8 @@ export type BackendType = {
   oldConfig?: APIServerConfig;
   songInfo?: SongInfo;
   currentRepeatMode?: RepeatMode;
-  volume?: number;
+  currentLikeType?: LikeType;
+  volumeState?: VolumeState;
 
   init: (ctx: BackendContext<APIServerConfig>) => Promise<void>;
   run: (hostname: string, port: number) => void;

--- a/src/plugins/shortcuts/mpris.ts
+++ b/src/plugins/shortcuts/mpris.ts
@@ -22,7 +22,7 @@ import getSongControls from '@/providers/song-controls';
 import config from '@/config';
 import { LoggerPrefix } from '@/utils';
 
-import type { RepeatMode } from '@/types/datahost-get-state';
+import type { RepeatMode, VolumeState } from '@/types/datahost-get-state';
 import type { QueueResponse } from '@/types/youtube-music-desktop-internal';
 
 class YTPlayer extends MprisPlayer {
@@ -305,8 +305,10 @@ function registerMPRIS(win: BrowserWindow) {
       console.trace(error);
     });
 
-    ipcMain.on('ytmd:volume-changed', (_, newVol) => {
-      player.volume = Number.parseFloat((newVol / 100).toFixed(2));
+    ipcMain.on('ytmd:volume-changed', (_, newVolumeState: VolumeState) => {
+      player.volume = newVolumeState.isMuted
+        ? 0
+        : Number.parseFloat((newVolumeState.state / 100).toFixed(2));
     });
 
     player.on('volume', (newVolume: number) => {

--- a/src/providers/song-controls.ts
+++ b/src/providers/song-controls.ts
@@ -1,5 +1,6 @@
 // This is used for to control the songs
 import { BrowserWindow, ipcMain } from 'electron';
+import { LikeType } from '@/types/datahost-get-state';
 
 // see protocol-handler.ts
 type ArgsType<T> = T | string[] | undefined;
@@ -42,8 +43,8 @@ export default (win: BrowserWindow) => {
     play: () => win.webContents.send('ytmd:play'),
     pause: () => win.webContents.send('ytmd:pause'),
     playPause: () => win.webContents.send('ytmd:toggle-play'),
-    like: () => win.webContents.send('ytmd:update-like', 'LIKE'),
-    dislike: () => win.webContents.send('ytmd:update-like', 'DISLIKE'),
+    like: () => win.webContents.send('ytmd:update-like', LikeType.Like),
+    dislike: () => win.webContents.send('ytmd:update-like', LikeType.Dislike),
     seekTo: (seconds: ArgsType<number>) => {
       const secondsNumber = parseNumberFromArgsType(seconds);
       if (secondsNumber !== null) {

--- a/src/types/datahost-get-state.ts
+++ b/src/types/datahost-get-state.ts
@@ -45,6 +45,11 @@ export enum LikeType {
   Like = 'LIKE',
 }
 
+export interface VolumeState {
+  state: number;
+  isMuted: boolean;
+}
+
 export interface MultiSelect {
   multiSelectedItems: Entities;
   latestMultiSelectIndex: number;


### PR DESCRIPTION
This PR includes a couple of small but useful improvements to the api-server:

_Volume State Endpoint:_
The volume state endpoint now includes a new `isMuted` boolean. It was a single `state` volume level before, now it also has `isMuted` property, to detect whether volume button is pressed (just what the `/v1/toggle-mute` does).

_New Like State Endpoint:_
Added a new endpoint: `GET /v1/like-state`
It returns the current song's like/dislike status, using the same values: `LIKE, DISLIKE, INDIFFERENT` as YouTube Music already has.