### PR TITLE
Prevent UI breakage on small window sizes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -343,8 +343,8 @@ async function createMainWindow() {
     titleBarStyle: useInlineMenu
       ? 'hidden'
       : is.macOS()
-        ? 'hiddenInset'
-        : 'default',
+      ? 'hiddenInset'
+      : 'default',
     autoHideMenuBar: config.get('options.hideMenu'),
   };
 
@@ -358,6 +358,8 @@ async function createMainWindow() {
     icon,
     width: windowSize.width,
     height: windowSize.height,
+    minWidth: 325,
+    minHeight: 425,
     backgroundColor: '#000',
     show: false,
     webPreferences: {
@@ -532,8 +534,8 @@ app.once('browser-window-created', (_event, win) => {
     const updatedUserAgent = is.macOS()
       ? userAgents.mac
       : is.windows()
-        ? userAgents.windows
-        : userAgents.linux;
+      ? userAgents.windows
+      : userAgents.linux;
 
     win.webContents.userAgent = updatedUserAgent;
     app.userAgentFallback = updatedUserAgent;
@@ -945,18 +947,15 @@ function removeContentSecurityPolicy(
   betterSession.webRequest.setResolver(
     'onHeadersReceived',
     async (listeners) => {
-      return listeners.reduce(
-        async (accumulator, listener) => {
-          const acc = await accumulator;
-          if (acc.cancel) {
-            return acc;
-          }
+      return listeners.reduce(async (accumulator, listener) => {
+        const acc = await accumulator;
+        if (acc.cancel) {
+          return acc;
+        }
 
-          const result = await listener.apply();
-          return { ...accumulator, ...result };
-        },
-        Promise.resolve({ cancel: false }),
-      );
+        const result = await listener.apply();
+        return { ...accumulator, ...result };
+      }, Promise.resolve({ cancel: false }));
     },
   );
 }


### PR DESCRIPTION
**Changes**
- Added minWidth: 325 and minHeight: 425 to **BrowserWindow** in **_index.ts_** to avoid layout issues
- This ensures the Music controls are visible in smallest window possible

**Before:**
<img width="185" height="559" alt="Screenshot 2025-07-12 at 1 02 33 PM" src="https://github.com/user-attachments/assets/4b12d0e2-b02b-431b-a702-d0afe864590d" />

**After:**
<img width="437" height="537" alt="Screenshot 2025-07-12 at 1 00 51 PM" src="https://github.com/user-attachments/assets/e0e63915-1ac9-4ed6-9a41-2bd29a77c3fd" />
