### PR TITLE
fix(api-server): Fixes the duplicated clientId saved in authorizedClients

### DIFF
--- a/src/plugins/api-server/backend/routes/auth.ts
+++ b/src/plugins/api-server/backend/routes/auth.ts
@@ -75,9 +75,11 @@ export const register = (
       // SKIP CHECK
     }
 
-    setConfig({
-      authorizedClients: [...config.authorizedClients, id],
-    });
+    if (!config.authorizedClients.includes(id)) {
+      setConfig({
+        authorizedClients: [...config.authorizedClients, id],
+      });
+    }
 
     const token = await sign(
       {


### PR DESCRIPTION
Trying to call /auth/{id} multiple times with the same id resulting in error 500 and duplicated ids in authorizedClients, this one fixes the issue.