### PR TITLE
feat: add custom window title option

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -34,6 +34,7 @@ export interface DefaultConfig {
     overrideUserAgent: boolean;
     usePodcastParticipantAsArtist: boolean;
     themes: string[];
+    customWindowTitle?: string;
   };
   'plugins': Record<string, unknown>;
 }

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -156,6 +156,13 @@
                 "hide": "Hide",
                 "label": "Like buttons"
               },
+              "custom-window-title": {
+                "label": "Custom window title",
+                "prompt": {
+                  "label": "Enter custom window title: (leave empty to disable)",
+                  "placeholder": "Example: YouTube Music"
+                }
+              },
               "remove-upgrade-button": "Remove upgrade button",
               "theme": {
                 "dialog": {
@@ -349,11 +356,11 @@
       "prompt": {
         "hostname": {
           "title": "Proxy Hostname",
-        "label": "Enter hostname for local proxy server (requires restart):"
+          "label": "Enter hostname for local proxy server (requires restart):"
         },
         "port": {
           "title": "Proxy Port",
-        "label": "Enter port for local proxy server (requires restart):"
+          "label": "Enter port for local proxy server (requires restart):"
         }
       }
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -599,6 +599,15 @@ app.once('browser-window-created', (_event, win) => {
   win.webContents.on('will-prevent-unload', (event) => {
     event.preventDefault();
   });
+
+  const customWindowTitle = config.get('options.customWindowTitle');
+
+  if (customWindowTitle) {
+    win.on('page-title-updated', (event) => {
+      event.preventDefault();
+      win.setTitle(customWindowTitle);
+    });
+  }
 });
 
 app.on('window-all-closed', () => {

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -218,6 +218,37 @@ export const mainMenuTemplate = async (
             },
             {
               label: t(
+                'main.menu.options.submenu.visual-tweaks.submenu.custom-window-title.label',
+              ),
+              async click() {
+                const output = await prompt(
+                  {
+                    title: t(
+                      'main.menu.options.submenu.visual-tweaks.submenu.custom-window-title.label',
+                    ),
+                    label: t(
+                      'main.menu.options.submenu.visual-tweaks.submenu.custom-window-title.prompt.label',
+                    ),
+                    value: config.get('options.customWindowTitle') || '',
+                    type: 'input',
+                    inputAttrs: {
+                      type: 'text',
+                      placeholder: t(
+                        'main.menu.options.submenu.visual-tweaks.submenu.custom-window-title.prompt.placeholder',
+                      ),
+                    },
+                    width: 500,
+                    ...promptOptions(),
+                  },
+                  win,
+                );
+                if (typeof output === 'string') {
+                  config.setMenuOption('options.customWindowTitle', output);
+                }
+              },
+            },
+            {
+              label: t(
                 'main.menu.options.submenu.visual-tweaks.submenu.like-buttons.label',
               ),
               submenu: [


### PR DESCRIPTION
This PR adds the ability to customize the main window title.
This is located at Menu bar > Options > Visual Tweaks > Custom window title.

This is useful for:
- Statically setting the window title
- Wanting a shorter title

For my use case, this is primarily to prevent very long titles as the window title depends on the currently playing song. This is more apparent on gtk3 where it interferes with the title bar buttons:

<img width="731" height="94" alt="Screenshot From 2025-07-20 21-03-01" src="https://github.com/user-attachments/assets/82bae246-1648-413f-8d29-a434cdc460fc" />

With custom window title:

<img width="560" height="82" alt="Screenshot From 2025-07-20 21-22-33" src="https://github.com/user-attachments/assets/7aa3c649-5efe-42c6-bf0b-7c9b0fe2f71f" />

This requires an app restart (like "Remove upgrade button").