### PR TITLE
feat(discord): add song & artist URLs to rich presence

### DIFF
--- a/src/plugins/discord/discord-service.ts
+++ b/src/plugins/discord/discord-service.ts
@@ -1,4 +1,7 @@
-import { Client as DiscordClient } from '@xhayper/discord-rpc';
+import {
+  Client as DiscordClient,
+  StatusDisplayType,
+} from '@xhayper/discord-rpc';
 import { dev } from 'electron-is';
 import { ActivityType } from 'discord-api-types/v10';
 
@@ -98,8 +101,11 @@ export class DiscordService {
 
     const activityInfo: SetActivity = {
       type: ActivityType.Listening,
+      statusDisplayType: StatusDisplayType.STATE,
       details: truncateString(songInfo.title, 128), // Song title
+      detailsUrl: songInfo.url,
       state: truncateString(songInfo.artist, 128), // Artist name
+      stateUrl: songInfo.artistUrl,
       largeImageKey: songInfo.imageSrc ?? undefined,
       largeImageText: songInfo.album
         ? truncateString(songInfo.album, 128)
@@ -109,7 +115,7 @@ export class DiscordService {
 
     // Handle paused state display
     if (songInfo.isPaused) {
-      activityInfo.largeImageText = '⏸︎';
+      activityInfo.largeImageText = '⏸';
     } else if (
       !config.hideDurationLeft &&
       songInfo.songDuration > 0 &&

--- a/src/plugins/discord/discord-service.ts
+++ b/src/plugins/discord/discord-service.ts
@@ -1,7 +1,4 @@
-import {
-  Client as DiscordClient,
-  StatusDisplayType,
-} from '@xhayper/discord-rpc';
+import { Client as DiscordClient } from '@xhayper/discord-rpc';
 import { dev } from 'electron-is';
 import { ActivityType } from 'discord-api-types/v10';
 
@@ -101,7 +98,6 @@ export class DiscordService {
 
     const activityInfo: SetActivity = {
       type: ActivityType.Listening,
-      statusDisplayType: StatusDisplayType.STATE,
       details: truncateString(songInfo.title, 128), // Song title
       detailsUrl: songInfo.url,
       state: truncateString(songInfo.artist, 128), // Artist name

--- a/src/providers/song-info.ts
+++ b/src/providers/song-info.ts
@@ -95,7 +95,7 @@ const handleData = async (
     songInfo.url = microformat.urlCanonical?.split('&')[0];
     songInfo.playlistId =
       new URL(microformat.urlCanonical).searchParams.get('list') ?? '';
-    songInfo.artistUrl = microformat.pageOwnerDetails.youtubeProfileUrl;
+    songInfo.artistUrl = `https://music.youtube.com/channel/${microformat.pageOwnerDetails.externalChannelId}`;
     // Used for options.resumeOnStart
     config.set('url', microformat.urlCanonical);
     songInfo.alternativeTitle = microformat.linkAlternates.find(

--- a/src/providers/song-info.ts
+++ b/src/providers/song-info.ts
@@ -30,6 +30,7 @@ export interface SongInfo {
   title: string;
   alternativeTitle?: string;
   artist: string;
+  artistUrl?: string;
   views: number;
   uploadDate?: string;
   imageSrc?: string | null;
@@ -72,6 +73,7 @@ const handleData = async (
     title: '',
     alternativeTitle: '',
     artist: '',
+    artistUrl: '',
     views: 0,
     uploadDate: '',
     imageSrc: '',
@@ -93,6 +95,7 @@ const handleData = async (
     songInfo.url = microformat.urlCanonical?.split('&')[0];
     songInfo.playlistId =
       new URL(microformat.urlCanonical).searchParams.get('list') ?? '';
+    songInfo.artistUrl = microformat.pageOwnerDetails.youtubeProfileUrl;
     // Used for options.resumeOnStart
     config.set('url', microformat.urlCanonical);
     songInfo.alternativeTitle = microformat.linkAlternates.find(
@@ -110,7 +113,7 @@ const handleData = async (
     songInfo.elapsedSeconds = videoDetails.elapsedSeconds;
     songInfo.isPaused = videoDetails.isPaused;
     songInfo.videoId = videoDetails.videoId;
-    songInfo.album = data?.videoDetails?.album; // Will be undefined if video exist
+    songInfo.album = videoDetails.album; // Will be undefined if video exist
 
     switch (videoDetails?.musicVideoType) {
       case 'MUSIC_VIDEO_TYPE_ATV':


### PR DESCRIPTION
hey there, dev who implemented the [new rich presence fields](https://github.com/discord/discord-api-docs/pull/7674) here :3

this pr adds clickable artist & song links to the rich presence. i looked through the payload to see if there's a good way to get the album URL, but i couldn't find a field that is reliable. i thought maybe playlistId would work, but when listening to a playlist its the id of the playlist the song is part of rather than the album.

[Screencast_20250810_084314.webm](https://github.com/user-attachments/assets/3e086e8c-1050-4a82-b5f0-9932cce24ca2)
