### PR TITLE
fix: move sendSongInfo to dataloaded event

### DIFF
--- a/src/providers/song-info-front.ts
+++ b/src/providers/song-info-front.ts
@@ -212,7 +212,6 @@ export default (api: YoutubePlayer) => {
 
     if (name === 'dataupdated' && waitingEvent.has(videoData.videoId)) {
       waitingEvent.delete(videoData.videoId);
-      sendSongInfo(videoData);
     } else if (name === 'dataloaded') {
       const video = document.querySelector<HTMLVideoElement>('video');
       video?.dispatchEvent(srcChangedEvent);
@@ -223,6 +222,7 @@ export default (api: YoutubePlayer) => {
       }
 
       waitingEvent.add(videoData.videoId);
+      sendSongInfo(videoData);
     }
   });
 


### PR DESCRIPTION
Fixes #3733

The event listener callback for `videodatachange` assumes that `dataloaded` comes first then `dataupdated` afterwards.

For songs this is the case. For albums though, it is the reverse, so the song info doesn't get updated as a result. This commit moves the updating of song info on `dataloaded` instead.

I haven't encountered issues after moving this so far, but if there are unintended side effects, please let me know.