### PR TITLE
Downloader: Add context menu button for playlists and albums

### DIFF
--- a/src/plugins/downloader/renderer.tsx
+++ b/src/plugins/downloader/renderer.tsx
@@ -6,7 +6,10 @@ import defaultConfig from '@/config/defaults';
 import { getSongMenu } from '@/providers/dom-elements';
 import { getSongInfo } from '@/providers/song-info-front';
 import { t } from '@/i18n';
-import { isMusicOrVideoTrack } from '@/plugins/utils/renderer/check';
+import {
+  isAlbumOrPlaylist,
+  isMusicOrVideoTrack,
+} from '@/plugins/utils/renderer/check';
 
 import { DownloadButton } from './templates/download';
 
@@ -25,7 +28,7 @@ const menuObserver = new MutationObserver(() => {
   if (
     !menu ||
     menu.contains(buttonContainer) ||
-    !isMusicOrVideoTrack() ||
+    !(isMusicOrVideoTrack() || isAlbumOrPlaylist()) ||
     !buttonContainer
   ) {
     return;

--- a/src/plugins/utils/renderer/check.ts
+++ b/src/plugins/utils/renderer/check.ts
@@ -22,6 +22,24 @@ export const isMusicOrVideoTrack = () => {
   return false;
 };
 
+export const isAlbumOrPlaylist = () => {
+  for (const menuSelector of document.querySelectorAll<
+    HTMLAnchorElement & {
+      data: {
+        addToPlaylistEndpoint: {
+          playlistId: string;
+        };
+        clickTrackingParams: string;
+      };
+    }
+  >('tp-yt-paper-listbox #navigation-endpoint')) {
+    if (menuSelector?.data?.addToPlaylistEndpoint?.playlistId) {
+      return true;
+    }
+  }
+  return false;
+};
+
 export const isPlayerMenu = (menu?: HTMLElement | null) => {
   return (
     menu?.parentElement as


### PR DESCRIPTION
Adds a check for album/playlist context menus so you don't have to go to the plugin menu every time you want to bulk download

<img width="494" height="402" alt="image" src="https://github.com/user-attachments/assets/278514cd-b2df-4a81-8243-a7cacab866aa" />
