### PR TITLE
Fix #3621

### DIFF
--- a/src/youtube-music.css
+++ b/src/youtube-music.css
@@ -33,11 +33,6 @@ ytmusic-app-layout {
   --ytmusic-nav-bar-height: 90px;
 }
 
-/* Blocking annoying elements */
-ytmusic-mealbar-promo-renderer {
-  display: none !important;
-}
-
 /* Disable Image Selection */
 img {
   -webkit-user-select: none;


### PR DESCRIPTION
This closes #3621

Initially I was trying to use CSS and Mutation Observer to remove the popup and the `inset` attribute it was adding, but after testing for some days by running from the source code, it turns out the problematic line was this:

```css
/* Blocking annoying elements */
ytmusic-mealbar-promo-renderer {
  display: none !important;
}
```

It's this popup which it blocks and hence why the UI becomes unreactive:
<img width="792" height="428" alt="image" src="https://github.com/user-attachments/assets/fb486c39-47d2-489f-9c9d-0e87783d435c" />

I don't think there's a need to write extra CSS or a JS script to block the `inset` attribute because this is a useful popup. And from my last few days of testing, I haven't seen any other annoying popups coming up, so this should be good to go.

However I would also suggest some people to test it and report because ads popups vary from region to region