### PR TITLE
fix(audio-compressor): real-time behavior and duplicated audio bug

### DIFF
--- a/src/plugins/audio-compressor.ts
+++ b/src/plugins/audio-compressor.ts
@@ -116,7 +116,6 @@ export default createPlugin({
 
     start() {
       document.addEventListener('ytmd:audio-can-play', audioCanPlayHandler, {
-        once: true,
         passive: true,
       });
       storage.connectToCompressor(


### PR DESCRIPTION
I noticed the compressor doesn't activate in real-time, but until the next song starts or when restarting the whole app.

The easy fix would be to add `restartNeeded: true,`
But I challenged myself to make it enable and disable in real-time.

My approximation was to make the `ensureAudioContextLoad` function because the 'ytmd:audio-can-play' event is only sent when loading a video. So it was impossible to know what song was playing at the moment the plugin was enabled.

By the way, it would have been easier if the audioSource and audioContext were sent when enabling a plugin, or the 'ytmd:audio-can-play' was sent again to plugins when enabled. Nevertheless, my pull request tries to modify only the plugin code and nothing from the source code.

I hope you like it.

> [!NOTE]
> All the scenarios I mentioned are more notorious if you have the 'Resume last song when app starts' option enabled.

<br>

> P.S. While making the fix, I realized the Exponential Volume plugin has a bug when starting the app, where it changes the volume to the max and only updates to the right value when changing the volume manually (just clicking the volume bar counts). #3787 

## Edit: TL;DR
Just realized this text is huge for no reason. In summary, my pull request offers:

### ADDED

- Enabling and disabling the compressor in real-time.

### FIXED

- Audio duplication.