### PR TITLE
Exponential Volume - Fixed volume desync bug

### DIFF
--- a/src/plugins/exponential-volume/index.ts
+++ b/src/plugins/exponential-volume/index.ts
@@ -1,5 +1,16 @@
 import { createPlugin } from '@/utils';
 import { t } from '@/i18n';
+import { YoutubePlayer } from '@/types/youtube-player';
+
+
+const syncVolume = (playerApi: YoutubePlayer) => {
+  if (playerApi.getPlayerState() === 3) {
+    setTimeout(() => syncVolume(playerApi), 500);
+    return;
+  }
+
+  playerApi.setVolume(playerApi.getVolume());
+}
 
 export default createPlugin({
   name: () => t('plugins.exponential-volume.name'),
@@ -9,7 +20,7 @@ export default createPlugin({
     enabled: false,
   },
   renderer: {
-    onPlayerApiReady() {
+    onPlayerApiReady(playerApi) {
       // "YouTube Music fix volume ratio 0.4" by Marco Pfeiffer
       // https://greasyfork.org/en/scripts/397686-youtube-music-fix-volume-ratio/
 
@@ -48,6 +59,7 @@ export default createPlugin({
           propertyDescriptor?.set?.call(this, lowVolume);
         },
       });
+      syncVolume(playerApi);
     },
   },
 });


### PR DESCRIPTION
There's a bug when having the Exponential Volume plugin enabled and starting the app, where the volume desyncs until you manually change the volume again. This fixes it.

By the way, I noticed there's a `playerApi.syncVolume()` function. But it turned the volume up to 100 lol
