### PR TITLE
feat(plugin): Custom Output Device plugin

### DIFF
--- a/src/plugins/custom-output-device/index.ts
+++ b/src/plugins/custom-output-device/index.ts
@@ -1,0 +1,56 @@
+// import { t } from "@/i18n";
+import promptOptions from "@/providers/prompt-options";
+import { createPlugin } from "@/utils";
+import prompt from "custom-electron-prompt";
+import { onConfigChange, start, stop } from "./renderer";
+
+export interface CustomOutputPluginConfig {
+  enabled: boolean;
+  output: string;
+  devices: Record<string, string>;
+}
+
+
+export default createPlugin({
+  name: () => 'Custom Output Device',
+  description: () => 'Configure a custom output media device for songs.',
+  restartNeeded: true,
+  config: {
+    enabled: false,
+    output: 'default',
+    devices: {}
+  } as CustomOutputPluginConfig,
+  menu: async ({ setConfig, getConfig, window }) => {
+
+    const promptDeviceSelector = async () => {
+      const options = await getConfig();
+
+      const response = await prompt({
+        title: 'Select Output Device',
+        label: 'Choose the output media device to be used',
+        value: options.output || 'default',
+        type: 'select',
+        selectOptions: options.devices,
+        width: 500,
+        ...promptOptions(),
+      }, window).catch(console.error);
+
+      if (!response) return;
+      options.output = response;
+      setConfig(options);
+    }
+
+    return [
+      {
+        label: 'Select Device',
+        click: () => promptDeviceSelector()
+      }
+    ]
+  },
+
+  renderer: {
+    start,
+    stop,
+    onConfigChange,
+  }
+})

--- a/src/plugins/custom-output-device/renderer.ts
+++ b/src/plugins/custom-output-device/renderer.ts
@@ -1,0 +1,55 @@
+import { CustomOutputPluginConfig } from ".";
+import { RendererContext } from "@/types/contexts";
+
+let options: CustomOutputPluginConfig;
+let audio_context: AudioContext;
+let first = true;
+
+export const updateDeviceList = async () => {
+  if (first) {
+    await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+    navigator.mediaDevices.ondevicechange = () => updateDeviceList()
+    first = false;
+  }
+
+  const new_devices: Record<string, string> = {};
+  const devices = await navigator.mediaDevices.enumerateDevices().then(devices => devices.filter(device => device.kind === 'audiooutput'));
+  for (const device of devices) {
+    new_devices[device.deviceId] = device.label;
+  }
+  options.devices = new_devices;
+  return options;
+}
+
+const updateSinkId = async (context: AudioContext) => {
+  if (!('setSinkId' in context)) {
+    console.log('setSinkId not in context')
+    return;
+  }
+  if (typeof context.setSinkId !== 'function') {
+    console.log('setSinkId not a function')
+    return;
+  }
+  await context.setSinkId(options.output)
+}
+
+const audioCanPlayHandler = ({ detail: { audioContext } }: CustomEvent<Compressor>) => {
+  audio_context = audioContext
+  updateSinkId(audioContext);
+}
+
+export const start = async (context: RendererContext<CustomOutputPluginConfig>) => {
+  options = await context.getConfig();
+
+  document.addEventListener('ytmd:audio-can-play', audioCanPlayHandler, { once: true, passive: true });
+  await context.setConfig(await updateDeviceList());
+}
+
+export const stop = () => {
+  document.removeEventListener('ytmd:audio-can-play', audioCanPlayHandler)
+}
+
+export const onConfigChange = (config: CustomOutputPluginConfig) => {
+  options = config;
+  updateSinkId(audio_context);
+}


### PR DESCRIPTION
A plugin that lets you choose the output media device that songs will use.
Simple and practical for those who have a mixer or multiple devices connected to the PC.
Useful for musicians, streamers, and some gamers who have audio setups.

<img width="486" height="193" alt="imagen" src="https://github.com/user-attachments/assets/5bd7e9ff-d49b-463c-bc86-174dfeef8966" />
<img width="115" height="173" alt="imagen" src="https://github.com/user-attachments/assets/4320e0ae-bb7f-4269-891c-c2c1fca8f3b2" />

I don't know if I had to provide the translations. In that case, let me know, and I will do it.