### PR TITLE
feat(api-server): Add Shuffle Changed updates for Websocket

### DIFF
--- a/src/plugins/api-server/backend/main.ts
+++ b/src/plugins/api-server/backend/main.ts
@@ -35,6 +35,7 @@ export const backend = createBackend<BackendType, APIServerConfig>({
       ctx.ipc.send('ytmd:setup-repeat-changed-listener');
       ctx.ipc.send('ytmd:setup-like-changed-listener');
       ctx.ipc.send('ytmd:setup-volume-changed-listener');
+      ctx.ipc.send('ytmd:setup-shuffle-changed-listener');
     });
 
     ctx.ipc.on(
@@ -45,6 +46,11 @@ export const backend = createBackend<BackendType, APIServerConfig>({
     ctx.ipc.on(
       'ytmd:volume-changed',
       (newVolumeState: VolumeState) => (this.volumeState = newVolumeState),
+    );
+
+    ctx.ipc.on(
+      'ytmd:shuffle-changed',
+      (newShuffleState: boolean) => (this.shuffleState = newShuffleState),
     );
 
     this.run(config.hostname, config.port);

--- a/src/plugins/api-server/backend/types.ts
+++ b/src/plugins/api-server/backend/types.ts
@@ -14,6 +14,7 @@ export type BackendType = {
   songInfo?: SongInfo;
   currentRepeatMode?: RepeatMode;
   volumeState?: VolumeState;
+  shuffleState?: boolean;
   injectWebSocket?: (server: ReturnType<typeof serve>) => void;
 
   init: (ctx: BackendContext<APIServerConfig>) => void;


### PR DESCRIPTION
This PR includes a feature for the websocket so that if the Shuffle State updates it send the state to the connected sockets.