### PR TITLE
security: Revert "fix(deps): update dependency color to v5.0.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "bgutils-js": "3.2.0",
     "butterchurn": "3.0.0-beta.5",
     "butterchurn-presets": "3.0.0-beta.4",
-    "color": "5.0.1",
+    "color": "5.0.0",
     "conf": "14.0.0",
     "custom-electron-prompt": "1.5.8",
     "deepmerge-ts": "7.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
         specifier: 3.0.0-beta.4
         version: 3.0.0-beta.4
       color:
-        specifier: 5.0.1
-        version: 5.0.1
+        specifier: 5.0.0
+        version: 5.0.0
       conf:
         specifier: 14.0.0
         version: 14.0.0
@@ -1914,8 +1914,8 @@ packages:
     resolution: {integrity: sha512-5z9FbYTZPAo8iKsNEqRNv+OlpBbDcoE+SY9GjLfDUHEfcNNV7tS9eSAlFHEaub/r5tBL9LtskAeq1l9SaoZ5tQ==}
     engines: {node: '>=18'}
 
-  color@5.0.1:
-    resolution: {integrity: sha512-6ckzzlDXoHjQW/gDy7yfbxHhWFLQKgKmp8zZxTjCXY8XtlGBJ5Xz39PWiiUsUvG71p1jjH/qvjmptQ6hfxLN/A==}
+  color@5.0.0:
+    resolution: {integrity: sha512-16BlyiuyLq3MLxpRWyOTiWsO3ii/eLQLJUQXBSNcxMBBSnyt1ee9YUdaozQp03ifwm5woztEZGDbk9RGVuCsdw==}
     engines: {node: '>=18'}
 
   combined-stream@1.0.8:
@@ -6539,7 +6539,7 @@ snapshots:
     dependencies:
       color-name: 2.0.0
 
-  color@5.0.1:
+  color@5.0.0:
     dependencies:
       color-convert: 3.1.0
       color-string: 2.0.1


### PR DESCRIPTION
Reverts th-ch/youtube-music#3846

see https://semgrep.dev/blog/2025/chalk-debug-and-color-on-npm-compromised-in-new-supply-chain-attack/