### PR TITLE
Fix `isEnabled` for platform-dependent plugins

### DIFF
--- a/src/config/plugins.ts
+++ b/src/config/plugins.ts
@@ -13,7 +13,7 @@ export function getPlugins() {
 
 export async function isEnabled(plugin: string) {
   const pluginConfig = deepmerge(
-    (await allPlugins())[plugin].config ?? { enabled: false },
+    (await allPlugins())[plugin]?.config ?? { enabled: false },
     (store.get('plugins') as Record<string, PluginConfig>)[plugin] ?? {},
   );
   return pluginConfig !== undefined && pluginConfig.enabled;


### PR DESCRIPTION
This PR fixes #3857 (and possibly other issues)

The issue was that `transparent-player` is only available for Windows, so it is not exposed in `allPlugins()[plugin]`, and when attempting to obtain `.config`, an exception occurred that prevented the plugin (album-color-theme) from working correctly.

With this one-character fix (yes, it's strange), everything returned to working order:
<img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/bcc80374-7b1b-4cfb-8b9e-28f4e394dd47" />
