### PR TITLE
feat: add WebSocket authentication

### DIFF
--- a/src/plugins/api-server/backend/main.ts
+++ b/src/plugins/api-server/backend/main.ts
@@ -117,8 +117,9 @@ export const backend = createBackend<BackendType, APIServerConfig>({
               ctx.set('jwtPayload', payload);
               return next();
             } catch (e) {
+              console.error(e);
               ctx.status(401);
-              return;
+              return ctx.body('Unauthorized');
             }
           }
         }


### PR DESCRIPTION
This PR fixes #3902 

Implements Websocket authentication using the `sec-websocket-protocol` header to pass the access_token.
This is a simple authentication method. This can be improved later by using ticketing authentication.

Frontend usage:
```js
const ws = new WebSocket(`${YTMDesktopUrl}/api/v1/ws`, ["access_token", accessToken]);
```