### PR TITLE
Fix GPU performance issue on macOS 26 by updating Electron version

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "cross-env": "10.0.0",
     "del-cli": "6.0.0",
     "discord-api-types": "0.38.23",
-    "electron": "38.0.0",
+    "electron": "38.2.0",
     "electron-builder": "26.0.12",
     "electron-builder-squirrel-windows": "26.0.12",
     "electron-devtools-installer": "4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         version: 1.0.1(@types/node@24.3.0)
       '@electron/remote':
         specifier: 2.1.3
-        version: 2.1.3(electron@38.0.0)
+        version: 2.1.3(electron@38.2.0)
       '@ffmpeg.wasm/core-mt':
         specifier: 0.12.0
         version: 0.12.0
@@ -59,10 +59,10 @@ importers:
         version: 2.0.5
       '@ghostery/adblocker-electron':
         specifier: 2.11.6
-        version: 2.11.6(electron@38.0.0)
+        version: 2.11.6(electron@38.2.0)
       '@ghostery/adblocker-electron-preload':
         specifier: 2.11.6
-        version: 2.11.6(electron@38.0.0)
+        version: 2.11.6(electron@38.2.0)
       '@hono/node-server':
         specifier: 1.19.1
         version: 1.19.1(hono@4.9.6)
@@ -119,7 +119,7 @@ importers:
         version: 14.0.0
       custom-electron-prompt:
         specifier: 1.5.8
-        version: 1.5.8(electron@38.0.0)
+        version: 1.5.8(electron@38.2.0)
       deepmerge-ts:
         specifier: 7.1.5
         version: 7.1.5
@@ -302,8 +302,8 @@ importers:
         specifier: 0.38.23
         version: 0.38.23
       electron:
-        specifier: 38.0.0
-        version: 38.0.0
+        specifier: 38.2.0
+        version: 38.2.0
       electron-builder:
         specifier: 26.0.12
         version: 26.0.12(electron-builder-squirrel-windows@26.0.12)
@@ -2319,8 +2319,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@38.0.0:
-    resolution: {integrity: sha512-egljptiPJqbL/oamFCEY+g3RNeONWTVxZSGeyLqzK8xq106JhzuxnhJZ3sxt4DzJFaofbGyGJA37Oe9d+gVzYw==}
+  electron@38.2.0:
+    resolution: {integrity: sha512-Cw5Mb+N5NxsG0Hc1qr8I65Kt5APRrbgTtEEn3zTod30UNJRnAE1xbGk/1NOaDn3ODzI/MYn6BzT9T9zreP7xWA==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -5143,9 +5143,9 @@ snapshots:
       - bluebird
       - supports-color
 
-  '@electron/remote@2.1.3(electron@38.0.0)':
+  '@electron/remote@2.1.3(electron@38.2.0)':
     dependencies:
-      electron: 38.0.0
+      electron: 38.2.0
 
   '@electron/universal@3.0.1':
     dependencies:
@@ -5336,16 +5336,16 @@ snapshots:
     dependencies:
       '@ghostery/adblocker-extended-selectors': 2.11.6
 
-  '@ghostery/adblocker-electron-preload@2.11.6(electron@38.0.0)':
+  '@ghostery/adblocker-electron-preload@2.11.6(electron@38.2.0)':
     dependencies:
       '@ghostery/adblocker-content': 2.11.6
-      electron: 38.0.0
+      electron: 38.2.0
 
-  '@ghostery/adblocker-electron@2.11.6(electron@38.0.0)':
+  '@ghostery/adblocker-electron@2.11.6(electron@38.2.0)':
     dependencies:
       '@ghostery/adblocker': 2.11.6
-      '@ghostery/adblocker-electron-preload': 2.11.6(electron@38.0.0)
-      electron: 38.0.0
+      '@ghostery/adblocker-electron-preload': 2.11.6(electron@38.2.0)
+      electron: 38.2.0
       tldts-experimental: 7.0.12
 
   '@ghostery/adblocker-extended-selectors@2.11.6': {}
@@ -5920,7 +5920,7 @@ snapshots:
 
   '@types/electron-localshortcut@3.1.3':
     dependencies:
-      electron: 38.0.0
+      electron: 38.2.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6803,9 +6803,9 @@ snapshots:
 
   csstype@3.1.3: {}
 
-  custom-electron-prompt@1.5.8(electron@38.0.0):
+  custom-electron-prompt@1.5.8(electron@38.2.0):
     dependencies:
-      electron: 38.0.0
+      electron: 38.2.0
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -7135,7 +7135,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@38.0.0:
+  electron@38.2.0:
     dependencies:
       '@electron/get': 2.0.3
       '@types/node': 22.17.2


### PR DESCRIPTION
# Fix GPU performance issue on macOS 26 by updating Electron version

## Description
This PR addresses the major GPU performance issue reported in [#3989](https://github.com/pear-devs/pear-desktop/issues/3989) where the app experiences lag, stutter, and momentary freezing on macOS 26.0.1.

## Problem
- App performance degrades significantly on macOS 26 (Tahoe)
- Users experience lag, stutter, and freezing when the app window is open
- Issue affects the overall user experience, especially on Apple Silicon devices

## Root Cause
The issue is related to Electron's use of private APIs that have been fixed in newer Electron versions. As mentioned in the issue, this was resolved in Electron versions:
- v38.2.0+
- v37.6.0+ 
- v36.9.2+

Reference: [electron/electron#48376](https://github.com/electron/electron/issues/48376)

## Solution
Updates Electron to the latest stable version that includes the GPU performance fix for macOS 26.

## Changes Made
- [x] Updated Electron version in `package.json`

## Testing
- Tested on macOS 26.0.1 (Apple Silicon)
- Verified smooth 120fps performance when app window is open


## Related Issues
Fixes [#3989](https://github.com/pear-devs/pear-desktop/issues/3989)