### PR TITLE
fix: Allow transparent player plugin to be used on all platforms

### DIFF
--- a/src/plugins/transparent-player/index.ts
+++ b/src/plugins/transparent-player/index.ts
@@ -22,7 +22,6 @@ export default createPlugin({
   description: () => t('plugins.transparent-player.description'),
   addedVersion: '3.11.x',
   restartNeeded: true,
-  platform: Platform.Windows,
   config: defaultConfig,
   stylesheets: [style],
   async menu({ getConfig, setConfig }) {


### PR DESCRIPTION
There is literally no reason to make it Windows only.
<img width="2561" height="1440" alt="image" src="https://github.com/user-attachments/assets/36d14f3b-3f93-48e5-a2ed-df3b6ed4d701" />
