### PR TITLE
Fix: MacOS install commands in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,16 +72,10 @@ this [wiki page](https://wiki.archlinux.org/index.php/Arch_User_Repository#Insta
 
 ### macOS
 
-You can install the app using Homebrew (see the [cask definition](https://github.com/pear-devs/pear-desktop-homebrew)):
-
-```bash
-brew install pear-devs/pear-desktop
-```
-
 If you install the app manually and get an error "is damaged and can’t be opened." when launching the app, run the following in the Terminal:
 
 ```bash
-/usr/bin/xattr -cr /Applications/Pear\ Desktop.app
+/usr/bin/xattr -cr /Applications/YouTube\ Music.app
 ```
 
 ### Windows


### PR DESCRIPTION
- Removed the Homebrew command as it's currently not working.
- Fixed the app name in the command that fixes the MacOS error when opening the app.