### PR TITLE
"feat(api-server): add /api/v1/queue/next endpoint

### DIFF
--- a/src/plugins/api-server/backend/routes/control.ts
+++ b/src/plugins/api-server/backend/routes/control.ts
@@ -422,13 +422,7 @@ const routes = {
         description: 'Success',
         content: {
           'application/json': {
-            schema: z.object({
-              title: z.string().optional(),
-              videoId: z.string().optional(),
-              thumbnail: z.any().optional(),
-              lengthText: z.any().optional(),
-              shortBylineText: z.any().optional(),
-            }),
+            schema: SongInfoSchema,
           },
         },
       },


### PR DESCRIPTION
## Description
Adds a new API endpoint `/api/v1/queue/next` to get information about the next song in the queue.

## Motivation
Closes #3614

This addresses the need for applications to preload the next song without parsing the entire queue response. The current `/api/v1/queue` endpoint returns a large amount of data, and extracting just the next song requires complex parsing.

## Changes
- Added new `GET /api/v1/queue/next` endpoint
- Returns next song information (title, videoId, thumbnail, etc.)
- Returns HTTP 204 when there's no next song
- Handles edge cases (empty queue, last song, etc.)

## Testing
- ✅ Tested with active queue (returns next song data)
- ✅ Tested with last song in queue (returns 204)
- ✅ Tested with empty queue (returns 204)
- ✅ Verified response format matches API conventions

## Example Usage
```bash
# Get next song
curl http://localhost:9863/api/v1/queue/next

# Example response
{
  "title": "Song Title",
  "videoId": "abc123",
  "thumbnail": {...},
  "lengthText": {...},
  "shortBylineText": {...}
}