### PR TITLE
Update Homebrew installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ this [wiki page](https://wiki.archlinux.org/index.php/Arch_User_Repository#Insta
 
 ### macOS
 
-You can install the app using Homebrew (see the [cask definition](https://github.com/pear-devs/pear-desktop-homebrew)):
+You can install the app using Homebrew (see the [cask definition](https://github.com/pear-devs/homebrew-pear)):
 
 ```bash
-brew install pear-devs/pear-desktop
+brew install pear-devs/pear/pear-desktop
 ```
 
 If you install the app manually and get an error "is damaged and can’t be opened." when launching the app, run the following in the Terminal:


### PR DESCRIPTION
This pull request updates the Homebrew installation instructions for macOS in the `README.md` file to point to the correct tap and cask definition.

* Updated the Homebrew tap and cask reference from `pear-devs/pear-desktop` to `pear-devs/pear/pear-desktop` and corrected the cask definition link.