### PR TITLE
feat(synced-lyrics): Improve LRC parsing

### DIFF
--- a/src/plugins/synced-lyrics/parsers/lrc.test.ts
+++ b/src/plugins/synced-lyrics/parsers/lrc.test.ts
@@ -17,28 +17,32 @@ test('chorus', () => {
 
   expect(lrc).toStrictEqual({
     lines: [
-      { duration: 12000, text: '', time: '0:0:0', timeInMs: 0 },
+      { duration: 12000, text: '', words: [], time: '00:00:00', timeInMs: 0 },
       {
         duration: 5020,
         text: 'Line 1 lyrics',
+        words: [],
         time: '00:12:00',
         timeInMs: 12000,
       },
       {
         duration: 3990,
         text: 'Line 2 lyrics',
+        words: [],
         time: '00:17:20',
         timeInMs: 17020,
       },
       {
         duration: 24000,
         text: 'Repeating lyrics (e.g. chorus)',
+        words: [],
         time: '00:21:10',
         timeInMs: 21010,
       },
       {
         duration: Infinity,
         text: 'Repeating lyrics (e.g. chorus)',
+        words: [],
         time: '00:45:10',
         timeInMs: 45010,
       },
@@ -61,16 +65,18 @@ test('attributes', () => {
 
   expect(lrc).toStrictEqual({
     lines: [
-      { duration: 12000, text: '', time: '0:0:0', timeInMs: 0 },
+      { duration: 12000, text: '', words: [], time: '00:00:00', timeInMs: 0 },
       {
         duration: 3030,
         text: 'Naku Penda Piya-Naku Taka Piya-Mpenziwe',
+        words: [],
         time: '00:12:00',
         timeInMs: 12000,
       },
       {
         duration: Infinity,
         text: 'Some more lyrics ...',
+        words: [],
         time: '00:15:30',
         timeInMs: 15030,
       },
@@ -82,5 +88,57 @@ test('attributes', () => {
       { tag: 'au', value: 'Written by Kal Mann / Dave Appell, 1961' },
       { tag: 'length', value: '2:23' },
     ],
+  });
+});
+
+test('karaoke', () => {
+  const lrc = LRC.parse(
+    '[00:00.00] <00:00.04> When <00:00.16> the <00:00.82> truth <00:01.29> is <00:01.63> found <00:03.09> to <00:03.37> be <00:05.92> lies',
+  );
+
+  expect(lrc).toStrictEqual({
+    lines: [
+      {
+        duration: Infinity,
+        text: 'When the truth is found to be lies',
+        time: '00:00:00',
+        timeInMs: 0,
+        words: [
+          {
+            timeInMs: 4,
+            word: 'When',
+          },
+          {
+            timeInMs: 16,
+            word: 'the',
+          },
+          {
+            timeInMs: 82,
+            word: 'truth',
+          },
+          {
+            timeInMs: 1029,
+            word: 'is',
+          },
+          {
+            timeInMs: 1063,
+            word: 'found',
+          },
+          {
+            timeInMs: 3009,
+            word: 'to',
+          },
+          {
+            timeInMs: 3037,
+            word: 'be',
+          },
+          {
+            timeInMs: 5092,
+            word: 'lies',
+          },
+        ],
+      },
+    ],
+    tags: [],
   });
 });


### PR DESCRIPTION
This PR adds two stuff:
1. Support for repeated-lyrics, aka chorus
2. Support for eLRC (karaoke)

<img width="500" height="463" alt="image" src="https://github.com/user-attachments/assets/a829ca39-0363-4208-a365-1920770ff4de" />

Resolves #4265
Resolves #4266