### PR TITLE
fix(api-server): add required 'alg' option to JWT middleware

### DIFF
--- a/src/plugins/api-server/backend/main.ts
+++ b/src/plugins/api-server/backend/main.ts
@@ -100,6 +100,7 @@ export const backend = createBackend<BackendType, APIServerConfig>({
       if (config.authStrategy !== AuthStrategy.NONE) {
         return await jwt({
           secret: config.secret,
+          alg: 'HS256',
         })(ctx, next);
       }
       await next();


### PR DESCRIPTION
## Problem

The `api-server` plugin's JWT middleware is missing the required `alg` option, which was introduced as a mandatory parameter in **Hono v4.11.10**. This causes **all `/api/*` endpoints to return HTTP 500 Internal Server Error**, completely breaking:

- REST API endpoints (`/api/v1/song`, `/api/v1/play`, etc.)
- WebSocket connections (`/api/v1/ws`)
- Any third-party client relying on the api-server plugin

### Error

```
Error: JWT auth middleware requires options for "alg"
    at jwt (hono/dist/middleware/jwt/jwt.js:12:11)
    at main.ts:101:22
```

## Fix

Added `alg: 'HS256'` to the `jwt()` middleware options in `src/plugins/api-server/backend/main.ts`. This matches the algorithm used by the `sign()` function in the auth route (`hono/jwt` defaults to HS256).

## Changes

- **`src/plugins/api-server/backend/main.ts`**: Added `alg: 'HS256'` to JWT middleware config (1 line)

## Testing

- Verified the API server starts without errors
- Confirmed `/api/v1/song` returns HTTP 200 with correct song data
- Confirmed `/auth/{id}` authentication flow works end-to-end
- WebSocket connections succeed on `/api/v1/ws`
